### PR TITLE
fix(call): handle missing texter_settings row + cleanup failed call logs

### DIFF
--- a/src/contexts/CallContext.tsx
+++ b/src/contexts/CallContext.tsx
@@ -40,6 +40,7 @@ import {
 } from '../services/agora';
 import {
   createCallLog,
+  deleteCallLog,
   updateCallStatus,
   endCallLog,
   sendCallSignal,
@@ -294,6 +295,9 @@ export function CallProvider({ children }: CallProviderProps) {
       // Get Agora token
       const { token, error: tokenError } = await getAgoraToken(chatId, callType);
       if (tokenError || !token) {
+        // Initieringen failade innan samtalet kunde nå mottagaren — ta bort
+        // den preliminära call_log:en så det inte loggas som "missat samtal".
+        await deleteCallLog(callLog.id);
         setCallError(mapCallError(tokenError, 'getAgoraToken'));
         setActiveCall((prev) => prev ? { ...prev, state: CallState.ENDED } : prev);
         setTimeout(() => cleanupCall(), 2500);

--- a/src/services/call.ts
+++ b/src/services/call.ts
@@ -66,6 +66,30 @@ export async function createCallLog(
 }
 
 /**
+ * Delete a call log. Används när initieringen failade och vi inte vill
+ * att ett vilseledande "missat samtal" ska finnas kvar hos mottagaren.
+ */
+export async function deleteCallLog(
+  callLogId: string
+): Promise<{ error: Error | null }> {
+  try {
+    const { error } = await supabase
+      .from('call_logs')
+      .delete()
+      .eq('id', callLogId);
+
+    if (error) {
+      return { error: new Error(error.message) };
+    }
+    return { error: null };
+  } catch (err) {
+    return {
+      error: err instanceof Error ? err : new Error('Unknown error'),
+    };
+  }
+}
+
+/**
  * Update the call log status.
  */
 export async function updateCallStatus(

--- a/supabase/functions/agora-token/index.ts
+++ b/supabase/functions/agora-token/index.ts
@@ -286,16 +286,22 @@ serve(async (req) => {
         .from('texter_settings')
         .select('can_voice_call, can_video_call')
         .eq('user_id', user.id)
-        .single();
+        .maybeSingle();
 
-      if (settingsError || !settings) {
+      if (settingsError) {
+        console.error('texter_settings query failed:', settingsError);
         return new Response(
-          JSON.stringify({ error: 'Call permission denied' }),
-          { status: 403, headers: { ...cors, 'Content-Type': 'application/json' } }
+          JSON.stringify({ error: 'Settings lookup failed' }),
+          { status: 500, headers: { ...cors, 'Content-Type': 'application/json' } }
         );
       }
 
-      const canCall = callType === 'video' ? settings.can_video_call : settings.can_voice_call;
+      // Saknad rad i texter_settings = nya texters defaults (allt tillåtet).
+      // Owner som vill stänga av samtal måste explicit skapa raden med false.
+      const canCall = settings
+        ? (callType === 'video' ? settings.can_video_call : settings.can_voice_call)
+        : true;
+
       if (!canCall) {
         return new Response(
           JSON.stringify({ error: 'Call permission denied' }),


### PR DESCRIPTION
## Summary

Två relaterade samtals-buggar som blockerade testringningar mellan användare.

**Bug 1 (#10):** `agora-token` edge function misslyckades med 403 när en Texter saknade rad i `texter_settings`. Query använde `.single()` som kastar fel vid saknad rad. Bytt till `.maybeSingle()` med default som tillåter samtal när rad saknas (matchar tabellens defaults).

**Bug 2 (#11):** `createCallLog` skapade en 'missed'-rad i databasen *innan* `getAgoraToken` anropades. När token-anropet failade låg call_log:en kvar och syntes som "missat samtal" hos mottagaren trots att samtalet aldrig kom igenom. La till `deleteCallLog` helper och anropar den i `CallContext` när token-anrop failar.

## Test plan

- [ ] Verifiera att Erik kan ringa Matilda (Texter utan texter_settings-rad) — samtalet ska initieras utan fel
- [ ] Verifiera att om token-anrop failar (t.ex. nätverksavbrott), så hamnar inte ett vilseledande "missat samtal" i mottagarens samtalshistorik
- [ ] Verifiera att existerande Texters med eget texter_settings (can_video_call = false) fortfarande blockeras korrekt

Closes #10
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
