### PR TITLE
fix: decline-notis, signal-cleanup, group-cap, chat-autoscroll

### DIFF
--- a/src/contexts/CallContext.tsx
+++ b/src/contexts/CallContext.tsx
@@ -17,6 +17,7 @@ import {
   CallType,
   VIDEO_CALL_MAX_DURATION_SECONDS,
   VIDEO_CALL_WARNING_SECONDS,
+  MAX_GROUP_CALL_PARTICIPANTS,
 } from '../types/call';
 import { SignalType, CallStatus } from '../types/database';
 import {
@@ -231,6 +232,12 @@ export function CallProvider({ children }: CallProviderProps) {
 
     // 2. Fetch other participant(s) info
     const otherMembers = await fetchOtherMembers(chatId, profile.id);
+
+    // 2b. Cap-kontroll: Agora gratis-tier tål bara så många deltagare.
+    if (1 + otherMembers.length > MAX_GROUP_CALL_PARTICIPANTS) {
+      setCallError('call.groupFull');
+      return;
+    }
 
     // 3. Create call log
     const { callLog, error: logError } = await createCallLog(chatId, callType);
@@ -568,6 +575,9 @@ export function CallProvider({ children }: CallProviderProps) {
     dismissNativeCallNotification();
     reportCallEnded(incomingCall.callLogId, 'declinedElsewhere');
     await updateCallStatus(incomingCall.callLogId, CallStatus.DECLINED);
+    // Skicka DECLINE-signal så att initiator får besked att samtalet
+    // avvisades — annars ringer det vidare för dem tills timeout.
+    await sendCallSignal(incomingCall.chatId, incomingCall.callLogId, SignalType.DECLINE);
     await deleteCallSignals(incomingCall.callLogId);
     setIncomingCall(null);
   }, [incomingCall]);
@@ -701,6 +711,19 @@ export function CallProvider({ children }: CallProviderProps) {
     if (!profile) return;
 
     const unsubscribe = subscribeToCallSignals(async (signal, caller) => {
+      // DECLINE-signal — vi är initiator och mottagaren har tackat nej.
+      // Stoppa det utgående samtalet och visa "Avvisat".
+      if (signal.signal_type === SignalType.DECLINE && activeCall && activeCall.callLogId === signal.call_log_id) {
+        if (ringTimeoutRef.current) {
+          clearTimeout(ringTimeoutRef.current);
+          ringTimeoutRef.current = null;
+        }
+        setActiveCall((prev) => prev ? { ...prev, state: CallState.ENDED } : prev);
+        setCallError('call.declined');
+        setTimeout(() => cleanupCall(), 2500);
+        return;
+      }
+
       if (activeCall) return;
 
       // Look up call type from the call log (signal itself doesn't carry it)

--- a/src/pages/ChatView.tsx
+++ b/src/pages/ChatView.tsx
@@ -313,19 +313,33 @@ const ChatView: React.FC = () => {
           return [...prev, newMessage];
         });
 
-        if (isNearBottomRef.current) {
-          scrollToBottomRef.current();
-        } else {
-          setNewMessageCount((n) => n + 1);
-        }
+        // Mät scroll-position FÄRSKT istället för cached ref. När användaren
+        // skriver i textarea triggas ingen scroll-event, så cached ref kan
+        // vara stale och nya meddelanden scrollas inte fram.
+        const computeNearBottom = async (): Promise<boolean> => {
+          const el = contentRef.current;
+          if (!el) return true;
+          const scrollEl = await el.getScrollElement();
+          const dist = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight;
+          return dist < 500;
+        };
+
+        computeNearBottom().then((near) => {
+          isNearBottomRef.current = near;
+          if (near) {
+            scrollToBottomRef.current();
+            if (newMessage.sender_id !== profile?.id) {
+              insertReadReceipts([newMessage.id]);
+            }
+          } else {
+            setNewMessageCount((n) => n + 1);
+          }
+        });
 
         loadReactionsRef.current([newMessage.id]);
 
         if (newMessage.sender_id !== profile?.id) {
           playReceiveSound();
-          if (isNearBottomRef.current) {
-            insertReadReceipts([newMessage.id]);
-          }
           markChatAsRead(chatId).then(() => refreshCounts());
         }
       },

--- a/src/types/call.ts
+++ b/src/types/call.ts
@@ -32,8 +32,8 @@ export enum SignalType {
 /** Maximum duration for video calls in seconds (60 minutes) */
 export const VIDEO_CALL_MAX_DURATION_SECONDS = 60 * 60;
 
-/** Maximum number of participants in a group call */
-export const MAX_GROUP_CALL_PARTICIPANTS = 4;
+/** Maximum number of participants in a group call (Agora-tier-cap). */
+export const MAX_GROUP_CALL_PARTICIPANTS = 6;
 
 /** Warning time before video call ends in seconds (at 55 minutes) */
 export const VIDEO_CALL_WARNING_SECONDS = 55 * 60;

--- a/supabase/migrations/20260426220000_cleanup_expired_call_signals.sql
+++ b/supabase/migrations/20260426220000_cleanup_expired_call_signals.sql
@@ -1,0 +1,29 @@
+-- Cleanup expired call_signals every 5 minutes via pg_cron.
+-- Signals have expires_at set on insert (typically a few minutes ahead);
+-- without cleanup the table grows unboundedly with stale rows.
+
+CREATE OR REPLACE FUNCTION cleanup_expired_call_signals()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  DELETE FROM call_signals
+  WHERE expires_at < now();
+END;
+$$;
+
+-- Schedule cleanup every 5 minutes. pg_cron is already enabled.
+-- Use INSERT ... ON CONFLICT to keep this migration idempotent if re-run.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'cleanup-expired-call-signals'
+  ) THEN
+    PERFORM cron.schedule(
+      'cleanup-expired-call-signals',
+      '*/5 * * * *',
+      'SELECT cleanup_expired_call_signals();'
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Fixar fyra buggar i samtals- och chat-flödena:

- **#1** Decline-notis: mottagaren skickar nu en `DECLINE`-signal som initiator lyssnar på och avslutar samtalet med "Avvisat" istället för att ringa vidare till timeout.
- **#2** Signal-cleanup: ny migration som schemalägger `pg_cron`-job var 5:e minut för att radera utgångna `call_signals`-rader.
- **#3** Group call-cap: höjd från 4 till 6 deltagare. Hård cap-kontroll i `initiateCall()` så samtal inte ens startas om gränsen skulle överskridas.
- **#8** Chat auto-scroll: räknar nu scroll-position färskt vid varje nytt meddelande istället för att lita på cached ref. Tröskel höjd från 200 → 500px.

## Test plan

- [ ] **#1**: A ringer B, B trycker Avvisa → A ser "Avvisat" och samtalet avslutas direkt
- [ ] **#2**: Verifiera i Supabase att rader med `expires_at < now()` raderas inom 5 min
- [ ] **#3**: Försök initiera samtal i grupp med >6 deltagare → felmeddelande visas, inget samtal initieras
- [ ] **#8**: Skriv i chat-input medan motparten skickar meddelande → ny meddelandet ska scrolla fram

#5 (emojis iOS) lämnas öppen — kommentar tillagd i issuet att rotorsaken behöver klargöras.

Closes #1
Closes #2
Closes #3
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
