### PR TITLE
docs(audit): comprehensive code audit for Fas 1 launch

### DIFF
--- a/tasks/audit-2026-04-26.md
+++ b/tasks/audit-2026-04-26.md
@@ -1,0 +1,412 @@
+# Audit-rapport 2026-04-26
+
+Granskning inför produktionslansering (deadline 2026-05-31) av Zemichat — Ionic + Capacitor (React/TS) klient mot Supabase, RevenueCat, Agora och FCM/APNs.
+
+## Sammanfattning
+
+Kodbasen är generellt mogen och väl strukturerad. RLS-grunden är genomtänkt och täcker alla kärntabeller med korrekta transparens-policies för Owner-oversight. GDPR-funktioner finns (export + delete), edge functions har rate limiting och input-validering, och RLS-tester finns för cirka hälften av tabellerna.
+
+Det finns dock **flera blockerande launchfynd**: chat-media-bucketen är konfigurerad som public (mediabilder kan nås utan auth om en URL läcker), `send-push` edge-funktionen accepterar requests utan autentisering, abonnemang synkas från RevenueCat via klienten (förfalskbar), `fetch-link-preview` saknar SSRF-skydd mot privata IP-adresser, och två edge-funktioner skickar HTML-mejl med oescapade användardata. Texter-inloggningen blockerar pausad/avstängd användare innan SOS kan skickas, vilket bryter mot säkerhetsdesignen där SOS aldrig ska kunna stängas av. Subscription-data till team uppdateras direkt från klient — det öppnar för stöld av Pro-funktioner.
+
+Vidare finns flera n+1-queries i Owner-oversight som blir långsamma vid skala, ett antal kvarvarande `.single()` där `.maybeSingle()` är säkrare, en `chat_members.user_id`-filterring som glöms bort, och stora pages (ChatView 1231 rader, Settings 1291 rader, ChatList 973 rader) som behöver delas. Minst 14 tabeller saknar RLS-tester, kritiska flöden (samtal, betalning, transparens) saknar enhets/integrationstest, och några säkerhetsrelaterade migrations är inte idempotenta.
+
+Bedömd tidsåtgång för P0/P1-fix före launch: 3-5 dagar koncentrerat arbete. Inget kräver omdesign, men vissa beslut (storage-bucket public/private, server-side webhook för RevenueCat) är arkitektoniska.
+
+## Kritiska fynd (P0/P1)
+
+| # | Fynd | Allvarsgrad | Område |
+|---|------|-------------|--------|
+| 1 | Chat-media-bucket är public — alla URL:er kan läsas utan auth | P0 | Säkerhet/GDPR |
+| 2 | `send-push` edge-funktion accepterar requests utan auth | P0 | Säkerhet |
+| 3 | RevenueCat-status synkas från klient → team.plan kan förfalskas | P0 | Säkerhet/Affär |
+| 4 | `fetch-link-preview` saknar SSRF-skydd | P0 | Säkerhet |
+| 5 | HTML-injection i `send-invitation` och `send-support-email` | P1 | Säkerhet |
+| 6 | Pausade/avstängda Texters blockeras före SOS kan skickas | P1 | Barnsäkerhet |
+| 7 | `delete_super_account` raderar hard messages → bryter Owner-transparens | P1 | Säkerhet/Affär |
+| 8 | Owner-oversight: n+1 queries + obegränsad messages-fetch | P1 | Prestanda |
+| 9 | `getChatMessages`: `.or('deleted_at.is.null,deleted_for_all.eq.true')` filtreras bort av RLS — placeholder-meddelanden visas aldrig för andra | P1 | Affärslogik |
+
+## Allvarliga fynd (P2)
+
+| # | Fynd | Område |
+|---|------|--------|
+| 10 | `chat.ts:330` — `currentMember`-query saknar `eq('user_id', user.id)`, oförutsägbart resultat för Owner | Robusthet |
+| 11 | `subscribeToCallSignals` har stale closure på `activeCall` → kanaler skapas/tas ner upprepade gånger | Robusthet |
+| 12 | `findExisting1on1Chat` n+1: queryar member-listan per chatt | Prestanda |
+| 13 | `polls`-RLS saknar `poll_options_select_owner` policy → Owner ser röster men inte alternativen | Säkerhet |
+| 14 | `messages_update_edit` policy: `chat_id = chat_id` är tautologi och blockar inte chat_id-byte | Säkerhet |
+| 15 | RevenueCat API-nycklar finns i `.env`-fil och skickas i klient-bundle (Public, men klienten är nu trovärdig) — saknas server-side validering | Säkerhet |
+| 16 | `auth.ts` — `signIn`/`signInAsTexter` returnerar fel där `is_active=false` upptäcks **efter** lyckad token-utdelning | Säkerhet |
+| 17 | `denied_friend_requests`-policy låter denied-listor läggas på Texter utan auth_user_role()-check (Owner kan denya för Owner) | Säkerhet |
+| 18 | Push-notifikationer skickar full content i title/body → läcker via lock-screen | Säkerhet/UX |
+| 19 | Saknade RLS-tester för 14 tabeller | Tester |
+| 20 | Edge functions: `console.error` läcker SQL/RLS-detaljer i Supabase-loggar | Säkerhet |
+| 21 | Generell brist på error-handling i React-komponenter (ChatView, OwnerOversight) | Robusthet |
+| 22 | `analytics_events`-tabell finns inte i någon migration — alla analytics-events misslyckas tyst | Robusthet |
+| 23 | `getMyChats` läser ALLA messages utan limit för att hitta last-message | Prestanda |
+
+## Mindre fynd (P3)
+
+| # | Fynd | Område |
+|---|------|--------|
+| 24 | `team.ts:51` `getMyTeam().single()` — kraschar om team saknas | Robusthet |
+| 25 | `team.ts:72` `getMyProfile().single()` — kraschar om profil saknas | Robusthet |
+| 26 | `usePresence:30` `.single()` — kraschar för raderade users | Robusthet |
+| 27 | `getCorsHeaders` defaultar till första origin vid okänd origin (acceptabelt men förvirrande) | Säkerhet |
+| 28 | `update_user_profile` accepterar valfri `avatar_url` upp till 500 chars (kan peka på extern bild) | Säkerhet |
+| 29 | `as unknown as` används 137 gånger — TypeScript-typer urvattnade på kritiska paths | Konsistens |
+| 30 | `docs/RLS.md` saknas (refererad från CLAUDE.md) | Dokumentation |
+| 31 | `Settings.tsx` 1291 rader, `ChatView.tsx` 1231 rader — stora pages | Konsistens |
+| 32 | Push-trigger har hårdkodad produktions-URL (om den ändras måste migration ändras) | Konfigurerbarhet |
+| 33 | `notify_new_message`-trigger saknar fallback om Edge function är nere | Robusthet |
+| 34 | `manual_subscriptions` saknar UPDATE/DELETE-policies → bara service-role kan skriva (bra), men ingen audit-logg | Säkerhet |
+| 35 | `send-push` skickar alltid badge=1 om unread-query failar (silent fallback) | Robusthet |
+| 36 | `subscribeToCallSignals` saknar filter — varje insert nationellt triggar callback (men RLS filtrerar) | Prestanda |
+| 37 | Inga tester för `auth.ts` MFA-flow, password reset, deactivation | Tester |
+| 38 | Inga tester för `oversight.ts` transparens-regler | Tester |
+| 39 | Inga tester för `subscription.ts` RevenueCat-integration | Tester |
+| 40 | Migrations använder INSERT istället för upsert för storage-bucket → re-run kraschar | Robusthet |
+
+## Per område
+
+### 1. Säkerhet (HÖGSTA PRIO)
+
+#### Fynd 1: Chat-media-bucket är public — URL:er kan läsas utan auth
+
+- **Fil:** `supabase/migrations/20260211130000_make_storage_public.sql:1-7` + `src/services/storage.ts:104-106` (alla `getPublicUrl`-anrop)
+- **Problem:** Migration sätter `chat-media`-bucketen till `public=true` med kommentaren "File paths contain UUIDs and timestamps, making them unguessable". Storage RLS skyddar bara INSERT/UPDATE/DELETE — när bucketen är public ignoreras SELECT-policyn helt. Det betyder att VEM SOM HELST som har en chat-media-URL kan läsa innehållet utan att vara inloggad. URL:en innehåller `{userId}/{chatId}/{timestamp}_{filename}` — om en URL läcker (screenshot, browser cache, support-mejl, server access logs, bug report) får mottagaren permanent obegränsad access.
+- **Risk:** GDPR-katastrof — barns bilder, röstmeddelanden, plats-information från chats läcker. Mediadelning av minderåriga kan inte återkallas. Sportadmin fick 6 mkr GDPR-bot för mindre allvarliga fel. Eftersom appen marknadsförs mot familjer med barn är detta sannolikt det enskilt allvarligaste fyndet.
+- **Allvarsgrad:** P0
+- **Föreslagen åtgärd:** Sätt `chat-media` bucket till `public=false` igen och migrera alla `getPublicUrl()`-anrop till `createSignedUrl()` med kortare TTL (t.ex. 1 h). Storage RLS finns redan på SELECT — den kommer då aktivt skydda. För wall-media där alla i teamet ska se: behåll RLS-policy `wall_media_select`. Ändring kräver att UI får signed URL via en service-funktion istället för att lagra publicUrl i `messages.media_url`. Alternativ: lagra bara `path` i DB, generera signed URL on-the-fly.
+
+#### Fynd 2: `send-push` edge-funktion accepterar requests utan autentisering
+
+- **Fil:** `supabase/functions/send-push/index.ts:223-239`
+- **Problem:** Funktionen läser bara payload `{ message_id, chat_id, sender_id, message_type, content }` — ingen `Authorization`-header krävs eller verifieras. Kommentaren säger "No CORS needed — this is triggered internally by pg_net" och "validates the payload by checking the message exists in the DB using its built-in SUPABASE_SERVICE_ROLE_KEY env var". Den enda verifieringen är att meddelandet existerar och är < 5 minuter gammalt. URL:en är publik (`https://qrrorlxocpxvqcfdipbq.supabase.co/functions/v1/send-push`) och hardkodad i `20260210150000_fix_push_trigger_no_alter_db.sql:37`.
+- **Risk:** En angripare kan POST:a meddelanden till URL:en med valfria `message_id`-värden som de hittat (t.ex. egna meddelanden från andra chattar) och spamma push till alla mottagare. Rate limit är per `sender_id` (60/min) — det går alltså att skicka 60 push per offer per minut. Om message_id:n inte är riktiga returnerar den bara 400. Inga signifikanta data läcker, men man kan skapa push-spam, brist på batterilivslängd, oönskade vibrationer/ringtoner mitt i natten för Texters/Supers.
+- **Allvarsgrad:** P0 (relativt lågt impact men trivialt att exploatera och påverkar barn)
+- **Föreslagen åtgärd:** Lägg till en delad hemlighet (`PG_NET_SHARED_SECRET`) som triggern skickar i `Authorization: Bearer ...` header och som edge-funktionen verifierar. Alternativ: använd Supabase Webhooks som har inbyggd JWT-signering. Tillsammans: behåll 5-min message-window-checken som defense-in-depth.
+
+#### Fynd 3: RevenueCat-status synkas från klient → team.plan kan förfalskas
+
+- **Fil:** `src/services/subscription.ts:415-440` (`syncSubscriptionToDatabase`)
+- **Problem:** Klienten läser RevenueCat `customerInfo` lokalt, mappar till en `SubscriptionStatus` och skickar till `teams.plan` via en direkt UPDATE-query. RLS-policyn `teams_update_owner` tillåter Owner att uppdatera sin egen team. En jailbroken iOS-enhet eller en hackad Android kan returnera vilken `customerInfo` som helst (eller anropa `syncSubscriptionToDatabase` direkt med en mockad status). Det innebär att en Owner kan ge sig själv Pro/Plus-plan utan att ha betalat.
+- **Risk:** Direkt intäktsförlust. RevenueCat har webhooks specifikt för denna risk — synkning från klient ses som anti-pattern i RevenueCat:s docs.
+- **Allvarsgrad:** P0
+- **Föreslagen åtgärd:** Implementera RevenueCat webhook → Supabase Edge function → uppdatera `teams.plan` med service-role-rättigheter. Ta bort `syncSubscriptionToDatabase` helt eller låt klienten endast trigga en `refresh`-RPC som verifierar mot RevenueCat:s server-API. Stryka direkträttigheten i `teams_update_owner` att uppdatera `plan`-kolumnen genom en strikt WITH CHECK eller en separat tabell `team_subscriptions` som bara servern skriver till.
+
+#### Fynd 4: `fetch-link-preview` saknar SSRF-skydd
+
+- **Fil:** `supabase/functions/fetch-link-preview/index.ts:55-79`
+- **Problem:** Funktionen tar emot en URL från klienten, validerar bara att protokollet är `http:` eller `https:`, och `fetch():ar` URL:en server-side. Inga restriktioner på hostname → angripare kan skicka URL:er till AWS metadata-tjänsten (`http://169.254.169.254/latest/meta-data/`), interna 10.x.x.x-adresser, localhost, eller redirect-kedjor till privata IP:er. Eftersom Supabase Edge functions kör på Deno Deploy är AWS-metadata sannolikt inte tillgängligt, men interna Supabase-resurser eller andra orchestration-lager kan vara det. HTML-svaret returneras till klienten — angripare kan extrahera intern info via meta-tags.
+- **Risk:** Klassisk SSRF. Beroende på Supabase Edge:s nätverksisolering kan detta läcka allt från VPC-IPs till AWS IAM-tokens om något körs i deras infrastruktur.
+- **Allvarsgrad:** P0
+- **Föreslagen åtgärd:** Före `fetch()`: gör DNS-resolution av hostname med `Deno.resolveDns(hostname, 'A')` och `Deno.resolveDns(hostname, 'AAAA')`. Avvisa om resultaten är i privata block: 10/8, 172.16/12, 192.168/16, 127/8, 169.254/16, ::1, fc00::/7, fe80::/10. Begränsa redirect-följning (`redirect: 'manual'` och re-validera redirect-URL:en). Begränsa Content-Type till `text/html`. Begränsa response size (5 MB max). Sätt timeout till 5 sek (redan gjort).
+
+#### Fynd 5: HTML-injection i `send-invitation` och `send-support-email`
+
+- **Fil:** `supabase/functions/send-invitation/index.ts:131-188`, `supabase/functions/send-support-email/index.ts:100-106`
+- **Problem:** Båda funktionerna interpolerar användardata direkt i HTML-mejl utan escape:
+  - `send-invitation`: `${recipientName}`, `${inviterName}`, `${teamName}`, `${inviteLink}` — mottagarens namn är från `display_name` (kan vara `<script>...</script>` eller `<img src=x onerror=...>`).
+  - `send-support-email`: `${email}`, `${subject}`, `${description}`, `${user.id}` injekteras i HTML, sedan `description.replace(/\n/g, '<br/>')` — body kan innehålla godtycklig HTML.
+- **Risk:** Email-clienter renderar HTML — phishing-länkar kan injiceras i auto-genererade mejl. Resend-mottagaren (`support@zemichat.com`) öppnar mejl med inbäddade trackers eller länk-injicerade phishing-sidor som ser ut att komma från Zemichat. För `send-invitation` kan inviteLink förgiftas eftersom det kommer från klienten — Owner skickar t.ex. ett konstigt inviteLink för att lura mottagaren.
+- **Allvarsgrad:** P1
+- **Föreslagen åtgärd:** Implementera en `escapeHtml()` helper som ersätter `&<>"'` med `&amp;` etc. Eller använd en mall-bibliotek som auto-escapar (t.ex. mustache). För `inviteLink`: validera att den börjar med `https://app.zemichat.com/invite/` på serversidan istället för att lita på klienten.
+
+#### Fynd 6: Pausade/avstängda Texters blockeras före SOS kan skickas
+
+- **Fil:** `src/services/auth.ts:120-138` (`signInAsTexter`)
+- **Problem:** RLS-policyn `sos_alerts_insert_texter` (migration 20260205120000:699-704) har medvetet INGEN `auth_user_is_active()`-check eftersom kommentaren säger "ONLY Texters can send SOS. NO is_active check — SOS can NEVER be disabled. This is a critical safety feature." MEN i `auth.ts:122-138` blockeras inloggning om `is_active=false` eller `is_paused=true` — dvs Texter kan inte ens få en session, vilket gör SOS omöjligt. Detta är direkt motsägelse mot säkerhetsdesignen.
+- **Risk:** Barn vars konto är pausat (t.ex. Owner stängde av som disciplinär åtgärd, eller pausat pga plan-medlemsgräns) kan inte trigga SOS i en akut situation. Det är livsfarligt.
+- **Allvarsgrad:** P1 (eskaleras till P0 om appen aktivt marknadsförs som familjesäkerhets-app)
+- **Föreslagen åtgärd:** Tillåt inloggning även för deaktiverade/pausade Texters men begränsa funktionalitet i UI till bara SOS-knappen + en "ditt konto är pausat"-skärm. Alternativ: skapa en separat SOS-only edge function som accepterar Texters Zemi-nummer + lösenord och skickar SOS direkt utan att kräva session. Den senare är säkrare eftersom auth-token i UI:n inte behövs.
+
+#### Fynd 7: `delete_super_account` raderar hard messages → bryter Owner-transparens
+
+- **Fil:** `supabase/migrations/20260209150000_gdpr_compliance.sql:319-325`
+- **Problem:** När en Super raderar sitt konto körs `DELETE FROM messages WHERE sender_id = v_uid`. Det är en hard delete — Owner förlorar permanent insyn i Super:s historiska meddelanden i Texter-chattar. PRD/CLAUDE.md säger explicit att Owner ska kunna se ALLA meddelanden inklusive raderade.
+- **Risk:** En Super som vill dölja något kan radera sitt konto → all historik försvinner. Det undergräver hela transparens-modellen och kan vara ett säkerhetsproblem för barn vars Super misshandlar dem.
+- **Allvarsgrad:** P1
+- **Föreslagen åtgärd:** Ändra till soft-delete istället: `UPDATE messages SET deleted_at = now(), deleted_by = v_uid WHERE sender_id = v_uid AND deleted_at IS NULL;`. Behåll meddelandena så Owner-oversight kan se dem. För GDPR: byt ut `content` mot `'[user deleted]'`-placeholder så data inte lämnas oraderad. Detta uppfyller GDPR (data minimering) samtidigt som transparens bevaras. Gör samma för `chats.created_by` (reassign till Owner är OK), men `messages.content` bör censureras inte raderas.
+
+#### Fynd 8: Owner-oversight: n+1 queries + obegränsad messages-fetch
+
+- **Fil:** `src/services/oversight.ts:113-130`
+- **Problem:** `getTexterChats` gör först `messages.select('*').in('chat_id', chatIds).order('created_at')` (rad 113-118) — UTAN limit, vilket kan returnera 10000+ rader. Sedan iterar genom `chatIds` och gör en `count`-query per chat (rad 124-129) — n+1 mönster.
+- **Risk:** Owner med många Texter-chattar kommer få långsam dashboard. På 100 chattar med 100 messages var = 10000 rader transit + 100 sekventiella queries ≈ 5-10 sekunder. Ger dåligt första intryck, sannolikt timeout-felkod 504.
+- **Allvarsgrad:** P1
+- **Föreslagen åtgärd:** Skriv en SECURITY DEFINER RPC `get_texter_chat_overview(team_id)` som med CTEs hämtar last_message + count i en query med `DISTINCT ON (chat_id)`. Eller använd en view: `CREATE VIEW texter_chat_overview AS SELECT chat_id, COUNT(*) AS message_count, MAX(created_at) AS last_message_at FROM messages GROUP BY chat_id;`. Då blir det 1 query istället för 1+N+1.
+
+#### Fynd 9: `getChatMessages`: `.or('deleted_at.is.null,deleted_for_all.eq.true')` filtreras bort av RLS
+
+- **Fil:** `src/services/message.ts:41`
+- **Problem:** Klient-koden försöker hämta soft-deleted-meddelanden med `deleted_for_all=true` (för att visa placeholder "Detta meddelande har raderats"). MEN RLS-policyn `messages_select_member` har `is_chat_member(chat_id) AND deleted_at IS NULL` — så för andra användare än sender filtreras `deleted_at IS NOT NULL`-rader bort på server-sidan, oavsett `deleted_for_all`.
+- **Risk:** Funktionalitet som "delete for all + visa placeholder" fungerar inte alls i praktiken. Andra användare ser meddelandet bara försvinna utan placeholder. PRD-funktion fungerar inte.
+- **Allvarsgrad:** P1 (funktionsbug, inget säkerhetshål — Owner-oversight kan fortfarande se via `messages_select_owner_oversight` som inte filtrerar deleted_at)
+- **Föreslagen åtgärd:** Uppdatera `messages_select_member`-policy till `is_chat_member(chat_id) AND (deleted_at IS NULL OR deleted_for_all = true)`. Då kan andra chat-medlemmar se raderade-för-alla-rader (med `content=null` och placeholder visas i UI baserat på `deleted_at` + `deleted_for_all`-flaggan).
+
+### 2. Robusthet
+
+#### Fynd 10: `chat.ts:330` — `currentMember`-query saknar `eq('user_id', user.id)`
+
+- **Fil:** `src/services/chat.ts:330-334`
+- **Problem:**
+```typescript
+const { data: currentMember } = await supabase
+  .from('chat_members')
+  .select('unread_count, is_pinned, ...')
+  .eq('chat_id', chatId)
+  .maybeSingle();
+```
+Filtret är bara på `chat_id` — om Owner kollar en Texter-chatt syns flera medlemmar. `.maybeSingle()` returnerar då fel `PGRST116` (multiple rows) eller bara en av raderna oförutsägbart.
+- **Risk:** För Owner som tittar i Texter-chattar visar UI:n fel pinned/archived/unread-status. Inte säkerhet, men funktionsbug.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Lägg till `.eq('user_id', user.id)` i query.
+
+#### Fynd 11: `subscribeToCallSignals` har stale closure på `activeCall`
+
+- **Fil:** `src/contexts/CallContext.tsx:710-755`
+- **Problem:** useEffect har `[profile, activeCall]` som dependencies → varje gång `activeCall` ändras körs cleanup + ny subscription. Eftersom `activeCall` ändras många gånger under ett samtal (mute, video, screen-share) skapas/tas ner Realtime-kanalen onödigt mycket. Mellan unsubscribe och resubscribe kan en RING-signal förloras.
+- **Risk:** Inkommande samtal kan missas mitt i ett pågående samtal. Också kostnad: extra Realtime-anslutningar.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Använd `useRef` för `activeCall` så att callbacken läser senaste värde utan att deps triggar resubscribe. Bara `[profile]` som deps.
+
+#### Fynd 12: `findExisting1on1Chat` n+1: queryar member-listan per chatt
+
+- **Fil:** `src/services/chat.ts:253-292`
+- **Problem:** Loopar genom alla 1-on-1 chats som user är medlem i och gör en separat `chat_members.select`-query per chat för att se om den andra användaren också är där.
+- **Risk:** För en aktiv Owner med 50+ chattar tar `createChat` 5+ sekunder (50 sekventiella queries).
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Skriv en RPC `find_existing_1on1_chat(other_user_id)` med JOIN, eller hämta alla `chat_members` för dessa chats i en query och gruppera i klienten.
+
+#### Fynd 13: `polls`-RLS saknar `poll_options_select_owner`
+
+- **Fil:** `supabase/migrations/20260209160000_add_polls_and_features.sql:88-108`
+- **Problem:** Owner har `polls_select_owner` och `poll_votes_select_owner` policies — men `poll_options` har bara `poll_options_select_member`. Det betyder Owner kan se polls och röster för en Texter-chatt MEN INTE alternativen. UI:n får då en poll med röster som pekar på okända options.
+- **Risk:** Owner-oversight bryter delvis. Funktionsbug, ingen läcka.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Lägg till en migration:
+```sql
+CREATE POLICY poll_options_select_owner ON poll_options
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM polls p
+      JOIN users u ON u.id = auth.uid()
+      WHERE p.id = poll_options.poll_id
+        AND u.role = 'owner'
+        AND chat_has_texter_from_team(p.chat_id, u.team_id)
+    )
+  );
+```
+
+#### Fynd 14: `messages_update_edit` policy: `chat_id = chat_id` är tautologi
+
+- **Fil:** `supabase/migrations/20260205120000_add_rls_policies.sql:478-482`
+- **Problem:** `WITH CHECK (sender_id = auth.uid() AND chat_id = chat_id AND deleted_at IS NULL)` — `chat_id = chat_id` är alltid `true` om `chat_id` inte är NULL. Avsikten var sannolikt att blockera ändring av `chat_id`. Korrekt PostgreSQL-syntax är att referera nya och gamla rader: i en BEFORE-trigger skulle man ha NEW och OLD, men i RLS finns inte OLD så `WITH CHECK` kan inte direkt jämföra mot gammal rad. Skyddet är alltså tomt.
+- **Risk:** Sender kan teoretiskt ändra `chat_id` på ett meddelande de äger till en annan chat de är medlem i. Detta skulle skifta meddelandet. RLS validerar inte att destinationen är OK eftersom `is_chat_member` bara körs på USING. Men `messages_update_edit` har `USING (sender_id = auth.uid() AND deleted_at IS NULL)` — utan chat_id-koll. Så jag kan editera meddelandet och flytta det till en annan chatt jag är medlem i.
+- **Risk-impact:** Låg → kräver att man manuellt skickar UPDATE via Supabase REST. Inte vanligt anfall, men formellt en transparency-breach (Owner ser inte längre meddelandet i ursprungschatten).
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Skapa en BEFORE UPDATE trigger som blockar ändringar i `chat_id` och `sender_id`:
+```sql
+CREATE OR REPLACE FUNCTION block_message_id_changes() ...
+  IF NEW.chat_id != OLD.chat_id OR NEW.sender_id != OLD.sender_id THEN
+    RAISE EXCEPTION 'chat_id/sender_id immutable';
+  END IF;
+```
+Eller: använd en separat RPC `edit_message(message_id, new_content)` som strikt validerar.
+
+#### Fynd 15: RevenueCat API-nycklar i klient-bundle
+
+- **Fil:** `.env:3-4`, `src/services/subscription.ts:18-19`
+- **Problem:** `VITE_REVENUECAT_*` är publika klient-keys (RevenueCat-kallar dem "public app keys"), så det är medvetet OK. Men dokumentera och flagga att alla klient-keys läcker är trivialt — verifiering måste ske server-side.
+- **Risk:** Tillsammans med Fynd 3 (klient-syncad subscription) blir attacken trivial.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Dokumentera. Om Fynd 3 åtgärdas (server-side webhook) är detta acceptabelt.
+
+#### Fynd 16: `auth.ts` — `is_active=false` kollas efter token-utdelning
+
+- **Fil:** `src/services/auth.ts:64-77, 117-130`
+- **Problem:** Logiken är: `signInWithPassword` → om lyckat, query `users.is_active`, om false → `signOut()`. Mellan signin och kollen finns en kort fönster där sessionen är aktiv. Om appen kraschar i mellan-tid kvarstår sessionen för en deaktiverad user.
+- **Risk:** Lågt — RLS skyddar fortfarande mot inserts/edits via `auth_user_is_active()` i policies. Men SELECT-tillgång finns kvar.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Implementera en login-blocker via Supabase Auth Hook (eller efter-login server-side check). Sätt en `auth.users.banned_until` i `auth.identities`-tabellen via en SECURITY DEFINER funktion när Owner deaktiverar Texter.
+
+#### Fynd 17: `denied_friend_requests`: kolla auth_user_role()
+
+- **Fil:** `supabase/migrations/20260205120000_add_rls_policies.sql:352-356`
+- **Problem:** `denied_friend_requests_insert_owner` har bara `WITH CHECK (is_team_owner_of(texter_id) AND denied_by = auth.uid())`. Saknar `AND auth_user_role() = 'owner'`. Om någon på något sätt blir definierad som "owner of texter" via en bug men har `super`-roll skulle de kunna denya. (`is_team_owner_of` checkar `teams.owner_id = auth.uid()` så praktiskt sett OK).
+- **Risk:** Defense-in-depth nedsatt, ingen direkt exploit.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Lägg till `auth_user_role() = 'owner'` som extra check.
+
+#### Fynd 18: Push-notifikationer skickar full content i title/body
+
+- **Fil:** `supabase/functions/send-push/index.ts:400-405`
+- **Problem:** För DM-chats blir `notificationTitle = senderName`, `body = content`. Hela meddelandet syns på låst skärm för iOS/Android. För en känslig konversation om barnsäker ämnen är detta läckage.
+- **Risk:** Föräldrar/syskon kan se barnens chatt-innehåll på lock-screen. Brister mot transparens-modellens andra sida — Texter har ingen privacy från andra (icke-Owner) tittare på samma device.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Skicka bara "Nytt meddelande" som body. Klienten kan visa innehållet när användaren öppnar appen. Eller, för iOS: använd `mutable-content: 1` och en Notification Service Extension som hämtar content efter biometric-unlock.
+
+#### Fynd 19: Saknade RLS-tester
+
+- **Fil:** `src/tests/rls/`
+- **Problem:** TECH_DEBT.md listar 14 tabeller utan tester: `call_signals`, `friend_settings`, `message_reactions`, `message_read_receipts`, `poll_options`, `poll_votes`, `team_invitations`, `wall_posts`, `wall_comments`, `wall_reactions`, `push_tokens`, `support_requests`, `referrals`, `manual_subscriptions` (har test). De flesta av dessa hanterar känsliga data.
+- **Risk:** Regressioner i RLS upptäcks inte automatiskt.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Skriv minst smoke-tester för: `wall_posts/wall_comments/wall_reactions` (cross-team-säkerhet), `poll_votes` (Owner-oversight), `team_invitations` (Owner-only).
+
+#### Fynd 20: Edge functions: `console.error` läcker SQL/RLS-detaljer
+
+- **Fil:** Flera edge-funktioner, t.ex. `send-invitation/index.ts:206`, `send-support-email/index.ts:124`, `agora-token/index.ts:292`
+- **Problem:** `console.error('Resend API error:', resendError);` skickas till Supabase logs. Resend-fel kan innehålla email-adresser och delar av request-bodyn. Inget direkt säkerhetshål, men persistens av PII.
+- **Risk:** GDPR-loggning utanför audit-strategi. Erik måste kunna radera dessa loggar om en användare ber.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Logga bara HTTP status och en error-id. Använd Sentry för felspårning utan att logga fullständig payload.
+
+#### Fynd 21: Brist på error-handling i React-komponenter
+
+- **Fil:** `src/pages/ChatView.tsx`, `src/pages/OwnerOversight.tsx`
+- **Problem:** Många service-anrop returnerar `{ data, error }` men error visas inte i UI; den loggas bara till console (eller ignoreras). Användaren ser "tom" data utan felmeddelande.
+- **Risk:** Användarens förvirring vid fel.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Implementera en gemensam toast/snackbar för fel via NotificationContext.
+
+#### Fynd 22: `analytics_events`-tabell finns inte i någon migration
+
+- **Fil:** `src/services/analytics.ts:50, 76`
+- **Problem:** Inserts till `analytics_events` görs men inga migrations skapar tabellen. Try/catch-blocket sväljer felet → analytics fungerar inte alls.
+- **Risk:** Insiktsförlust — ingen användardata samlas in. Om `trackEvent` aktiveras med RLS som tillåter alla anonyma att läsa kan en framtida regression läcka data.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Skapa migration:
+```sql
+CREATE TABLE analytics_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  team_id uuid,
+  event_type text NOT NULL,
+  metadata jsonb,
+  platform text,
+  app_version text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE analytics_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY analytics_events_insert_self ON analytics_events
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+-- No SELECT policy → only service_role kan läsa
+```
+
+#### Fynd 23: `getMyChats` läser ALLA messages utan limit
+
+- **Fil:** `src/services/chat.ts:101-106`
+- **Problem:** Hämtar alla non-deleted messages för alla user:s chats för att hitta last message — ingen `.limit()`, ingen `DISTINCT ON`.
+- **Risk:** För användare med 50+ chats × 1000 msgs = 50000 rader transit per Chat-Tab refresh. Snabbt batteri- och nätverksdräp.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Använd RPC med `DISTINCT ON (chat_id) ... ORDER BY chat_id, created_at DESC`.
+
+### 3. Prestanda
+
+(Övergripande noterat under Robusthet — Fynd 8, 12, 23.)
+
+#### Fynd: Realtime subscriptions cleanup
+
+- **Fil:** Genomgånget — cleanup ser ut OK på alla `subscribeTo*`-anrop. `removeChannel` kallas på unmount.
+- **Status:** ✅ OK i de granskade kontexterna.
+
+#### Fynd: Bundle splitting
+
+- **Fil:** `vite.config.ts:19-30`
+- **Status:** ✅ Bra split — agora, emoji-picker, leaflet, supabase, vendor är separata chunks. Dokumenterat i TECH_DEBT.md att initial gzip har sjunkit från 1010 KB till 278 KB.
+
+#### Fynd: Image-komprimering
+
+- **Fil:** `src/services/storage.ts:65-130` (`uploadImage`)
+- **Problem:** Ingen klient-side komprimering av uploaded images. En 12 MP-bild från modern telefon är 5-8 MB.
+- **Risk:** Långsamma uploads + onödig storage-kostnad.
+- **Allvarsgrad:** P2
+- **Föreslagen åtgärd:** Använd `<canvas>` eller `browser-image-compression`-bibliotek för att skala till max 1920px och komprimera JPEG till quality 0.85 innan upload.
+
+### 4. Konsistens & kodstandard
+
+#### Fynd 29: `as unknown as` används 137 gånger
+
+- **Status:** Bekräftat i TECH_DEBT.md som teknisk skuld (27 filer, 30 `any`-typer).
+- **Föreslagen åtgärd:** Generera typer från Supabase med `npx supabase gen types typescript` och uppdatera `src/types/database.ts` så `select<T>()` returnerar rätt typ. Iterativ migrering från cast till typed.
+
+#### Fynd: Service-mönster
+
+- **Status:** ✅ Mestadels följt — alla DB-anrop i `src/services/*.ts`. Få avvikelser (CallContext.tsx gör direkta queries på rad 190-208 + 603-607 + 731-735, ChatView.tsx läser från en service).
+- **Föreslagen åtgärd:** Flytta de tre direkta queries i CallContext till en service.
+
+#### Fynd 30: `docs/RLS.md` saknas
+
+- **Fil:** `docs/`
+- **Problem:** CLAUDE.md refererar till `./docs/RLS.md` men filen finns inte. Ny utvecklare har bara migrations att gå på.
+- **Allvarsgrad:** P3
+- **Föreslagen åtgärd:** Skapa `docs/RLS.md` med översikt över alla policies grupperade per tabell, deras motivering, och hur transparens uppfylls.
+
+#### Fynd 31: Stora pages
+
+- **Fil:** `Settings.tsx` (1291), `ChatView.tsx` (1231), `ChatList.tsx` (973)
+- **Status:** Dokumenterat i TECH_DEBT.md som "Deferred — high effort". Borde göras innan launch eftersom de är de mest-edited filerna.
+
+### 5. Arkitektur
+
+#### Frontend ↔ Supabase via service layer
+
+- **Status:** Mestadels OK, med några undantag (CallContext, vissa pages).
+
+#### Edge functions: gemensam kod
+
+- **Status:** ✅ `_shared/cors.ts` och `_shared/rate-limit.ts` används konsekvent.
+
+#### Migrations: idempotens
+
+- **Fil:** `supabase/migrations/20260206150000_add_storage_buckets.sql:9` — `INSERT INTO storage.buckets (...) VALUES (...)` saknar `ON CONFLICT DO NOTHING`. Re-running migrations kraschar.
+- **Allvarsgrad:** P3
+- **Föreslagen åtgärd:** Lägg till `ON CONFLICT (id) DO UPDATE SET ...` eller `DO NOTHING`. Migration `20260407200000_add_avatar_upload.sql` gör det rätt.
+
+#### State management
+
+- **Status:** Mest Context-baserat (Auth, Subscription, Notification, Call, Theme). Inga `stores/` används (mappen är tom). Acceptabelt val för app-storleken.
+
+### 6. Testtäckning
+
+#### Befintliga tester
+
+- **RLS-tester (16 filer i src/tests/rls/):** call-logs, chat-members, chats, denied-friend-requests, device, friendships, manual-subscriptions, message-ancillary, messages, quick-messages, reports, sos-alerts, teams, texter-settings, users.
+- **E2E-tester (2 filer):** call.e2e.test.ts (343 rader), push.e2e.test.ts (287 rader).
+- **Unit-tester:** Bara `App.test.tsx` (smoke).
+
+#### Saknade tester
+
+- **RLS:** wall_posts/comments/reactions, poll_options/votes, message_reactions/read_receipts, friend_settings, push_tokens, team_invitations, support_requests, referrals, polls.
+- **Service-unit:** auth.ts (MFA, password reset), subscription.ts (RevenueCat-integration), oversight.ts (transparens-regler), member.ts (disabled-texter blocking), storage.ts.
+- **E2E kritiska flöden:** Inga tester för: Owner deaktiverar Texter → blocked, Owner ser Texter:s soft-deleted message, Texter försöker bypassa permissions, betalningsflöde end-to-end, transparens av polls/wall.
+
+#### Föreslagen åtgärd
+
+- Före launch: skriv RLS-tests för polls, wall_*, message_reactions/read_receipts, push_tokens — ungefär 1 dag.
+- Skriv unit-tests för `oversight.ts.getTexterChats()` (transparens) och `subscription.ts.getSubscriptionStatus()` — ungefär 1 dag.
+- E2E: Owner-Texter-Super flow för deaktivering → blocked, Owner ser raderat meddelande — 1 dag.
+
+## Starkaste positiva observationer
+
+1. **RLS-grunden är genomtänkt** — `auth_user_role()`, `is_team_owner_of()`, `chat_has_texter_from_team()` är väl-namngivna SECURITY DEFINER helpers. Transparens-policies (`messages_select_owner_oversight` etc) är konsekvent implementerade på alla relevanta tabeller. Indexar finns för `chat_members(chat_id, user_id) WHERE left_at IS NULL` och `users(team_id, role)`.
+
+2. **GDPR-funktioner finns:** `export_user_data()` returnerar både skickade OCH mottagna meddelanden, plus alla relaterade tabeller. `delete_owner_account()` raderar hela teamet med audit-logg via SHA-256 hash av team-namn. `account_deletion_log` är anonymiserat. Bättre än många stora SaaS-aktörer.
+
+3. **Edge functions har rate limiting** via gemensam `_shared/rate-limit.ts` med pg_net-baserad räknare. Alla autentiserade endpoints (`agora-token`, `call-push`, `send-invitation`, `fetch-link-preview`, `send-support-email`) har rimliga gränser (5-30/min). Input-validering med UUID-regex och längdkontroller är konsekvent.
+
+4. **Bundle splitting och TypeScript-strikthet är på rätt väg.** TECH_DEBT.md är välorganiserat med dokumenterad progress. ESLint-reglerna (`no-explicit-any: warn`, `no-console: warn except warn/error`, `no-fallthrough: error`) plus aktiv migrering bort från `.single()` till `.maybeSingle()` visar disciplin.
+
+5. **Texter-account-modellen är elegant:** falsk-email + hashad password via `extensions.crypt(... gen_salt('bf'))`, så Texter får riktig auth.users-rad utan email-verifiering. Auto-friendship med team-medlemmar vid skapande. Owner kan deaktivera/pausa via simple `is_active`/`is_paused`-flaggor som RLS lyssnar på via `auth_user_is_active()`.
+
+## Top-3 mest kritiska fynd att fixa OMEDELBART innan launch
+
+1. **Fynd 1 — Chat-media-bucket public:** Migrera till `public=false` + `getSignedUrl()` med 1h TTL. GDPR-blockerare för barn-app. Estimat: 1-2 dagars arbete (RLS finns redan).
+
+2. **Fynd 3 — RevenueCat klient-syncad subscription:** Implementera RevenueCat webhook → Edge function → service-role-update. Förfalskning av Pro-plan är trivialt idag. Estimat: 1 dag.
+
+3. **Fynd 2 — `send-push` saknar autentisering:** Lägg till delad hemlighet i Authorization-header som triggern skickar och edge-funktionen verifierar. Estimat: 2-3 timmar.
+
+Tillsammans är detta ~3 dagars arbete och eliminerar de tre allvarligaste laucnh-blockers. Fynd 4 (SSRF), Fynd 5 (HTML-injection), Fynd 6 (SOS-blockering) bör också vara fixade före publik release men är mindre exponerade än de tre topp-fynden.


### PR DESCRIPTION
Audit-rapport med 40 fynd inför produktionslansering. P0/P1-fynd får egna issues med Typ=Release-blockerare för triagering på boarden.