### PR TITLE
feat(reports): in-app reporting + Owner moderation overview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ import OwnerApprovals from './pages/OwnerApprovals';
 import MFASetup from './pages/MFASetup';
 import MFAVerify from './pages/MFAVerify';
 import Support from './pages/Support';
+import TeamReports from './pages/TeamReports';
 
 /* Welcome & Onboarding */
 import Welcome from './pages/Welcome';
@@ -286,6 +287,9 @@ const App: React.FC = () => (
             </PrivateRoute>
             <PrivateRoute exact path="/support">
               <Support />
+            </PrivateRoute>
+            <PrivateRoute exact path="/team-reports">
+              <TeamReports />
             </PrivateRoute>
             <PrivateRoute exact path="/choose-plan">
               <ChoosePlan />

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  IonModal,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonButtons,
+  IonButton,
+  IonContent,
+  IonItem,
+  IonLabel,
+  IonRadio,
+  IonRadioGroup,
+  IonTextarea,
+  IonIcon,
+  IonText,
+  IonSpinner,
+} from '@ionic/react';
+import { flagOutline, checkmarkCircleOutline } from 'ionicons/icons';
+import { ReportCategory } from '../types/database';
+import {
+  reportChat,
+  reportMessage,
+  reportUser,
+  REPORT_CATEGORY_ORDER,
+} from '../services/report';
+
+type ReportTarget =
+  | { kind: 'message'; messageId: string }
+  | { kind: 'chat'; chatId: string }
+  | { kind: 'user'; userId: string };
+
+interface ReportButtonProps {
+  /** What is being reported. Determines which service call we make. */
+  target: ReportTarget;
+  /**
+   * Visual style. `link` is plain inline text (e.g. inside a context
+   * menu); `button` is a standalone button. Defaults to `link`.
+   */
+  variant?: 'link' | 'button';
+  /** Optional override label; falls back to the translated default. */
+  label?: string;
+  /** Called after the user has either submitted or cancelled. */
+  onClose?: () => void;
+  /** Hides the trigger and forces the modal open — handy when the
+   * caller wants to drive the lifecycle (e.g. from a long-press menu
+   * that already closed). */
+  forceOpen?: boolean;
+}
+
+const ReportButton: React.FC<ReportButtonProps> = ({
+  target,
+  variant = 'link',
+  label,
+  onClose,
+  forceOpen,
+}) => {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [category, setCategory] = useState<ReportCategory | null>(null);
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const open = forceOpen ?? isOpen;
+
+  const defaultLabel =
+    target.kind === 'message'
+      ? t('report.reportMessage')
+      : target.kind === 'chat'
+        ? t('report.reportChat')
+        : t('report.reportUser');
+
+  const trigger = label ?? defaultLabel;
+
+  const close = () => {
+    setIsOpen(false);
+    setCategory(null);
+    setDescription('');
+    setSubmitting(false);
+    setSubmitted(false);
+    setErrorMessage(null);
+    onClose?.();
+  };
+
+  const submit = async () => {
+    if (!category || submitting) return;
+    setSubmitting(true);
+    setErrorMessage(null);
+
+    const trimmed = description.trim();
+    const desc = trimmed.length > 0 ? trimmed : undefined;
+
+    let res;
+    if (target.kind === 'message') {
+      res = await reportMessage(target.messageId, category, desc);
+    } else if (target.kind === 'chat') {
+      res = await reportChat(target.chatId, category, desc);
+    } else {
+      res = await reportUser(target.userId, category, desc);
+    }
+
+    setSubmitting(false);
+    if (res.error) {
+      setErrorMessage(t('report.errorGeneric'));
+      return;
+    }
+    setSubmitted(true);
+  };
+
+  return (
+    <>
+      {!forceOpen && (
+        variant === 'button' ? (
+          <IonButton
+            fill="outline"
+            color="danger"
+            onClick={() => setIsOpen(true)}
+          >
+            <IonIcon slot="start" icon={flagOutline} />
+            {trigger}
+          </IonButton>
+        ) : (
+          <button
+            type="button"
+            className="report-link"
+            onClick={() => setIsOpen(true)}
+          >
+            <IonIcon icon={flagOutline} />
+            <span>{trigger}</span>
+            <style>{`
+              .report-link {
+                display: flex;
+                align-items: center;
+                gap: 0.5rem;
+                background: transparent;
+                border: none;
+                color: var(--ion-color-danger, #eb445a);
+                padding: 0.5rem 0.75rem;
+                font: inherit;
+                cursor: pointer;
+              }
+              .report-link:active { opacity: 0.6; }
+            `}</style>
+          </button>
+        )
+      )}
+
+      <IonModal
+        isOpen={open}
+        onDidDismiss={close}
+        breakpoints={[0, 0.6, 1]}
+        initialBreakpoint={0.85}
+      >
+        <IonHeader>
+          <IonToolbar>
+            <IonTitle>{t('report.title')}</IonTitle>
+            <IonButtons slot="end">
+              <IonButton onClick={close}>{t('report.cancel')}</IonButton>
+            </IonButtons>
+          </IonToolbar>
+        </IonHeader>
+        <IonContent className="ion-padding">
+          {submitted ? (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '1rem',
+                padding: '2rem 1rem',
+                textAlign: 'center',
+              }}
+            >
+              <IonIcon
+                icon={checkmarkCircleOutline}
+                style={{ fontSize: '3rem', color: 'var(--ion-color-success)' }}
+              />
+              <IonText>{t('report.success')}</IonText>
+              <IonButton onClick={close}>{t('report.cancel')}</IonButton>
+            </div>
+          ) : (
+            <>
+              <IonItem lines="none">
+                <IonLabel>
+                  <strong>{t('report.categoryLabel')}</strong>
+                </IonLabel>
+              </IonItem>
+              <IonRadioGroup
+                value={category}
+                onIonChange={(e) =>
+                  setCategory((e.detail.value as ReportCategory) ?? null)
+                }
+              >
+                {REPORT_CATEGORY_ORDER.map((c) => (
+                  <IonItem key={c}>
+                    <IonRadio
+                      slot="start"
+                      value={c}
+                      aria-label={t(`report.categories.${c}`)}
+                    />
+                    <IonLabel>{t(`report.categories.${c}`)}</IonLabel>
+                  </IonItem>
+                ))}
+              </IonRadioGroup>
+
+              <IonItem lines="none" style={{ marginTop: '1rem' }}>
+                <IonLabel position="stacked">
+                  {t('report.descriptionLabel')}
+                </IonLabel>
+                <IonTextarea
+                  value={description}
+                  onIonInput={(e) =>
+                    setDescription((e.detail.value as string) ?? '')
+                  }
+                  placeholder={t('report.descriptionPlaceholder')}
+                  maxlength={2000}
+                  autoGrow
+                  rows={4}
+                />
+              </IonItem>
+
+              {errorMessage && (
+                <IonText color="danger">
+                  <p style={{ padding: '0 1rem' }}>{errorMessage}</p>
+                </IonText>
+              )}
+
+              <div style={{ padding: '1rem' }}>
+                <IonButton
+                  expand="block"
+                  color="danger"
+                  onClick={submit}
+                  disabled={!category || submitting}
+                >
+                  {submitting ? (
+                    <>
+                      <IonSpinner slot="start" name="crescent" />
+                      {t('report.submitting')}
+                    </>
+                  ) : (
+                    t('report.submit')
+                  )}
+                </IonButton>
+              </div>
+            </>
+          )}
+        </IonContent>
+      </IonModal>
+    </>
+  );
+};
+
+export default ReportButton;

--- a/src/components/chat/MessageContextMenu.tsx
+++ b/src/components/chat/MessageContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   createOutline,
   arrowRedoOutline,
   trashOutline,
+  flagOutline,
 } from 'ionicons/icons';
 import { type MessageWithSender, canEditMessage, canDeleteForAll } from '../../services/message';
 import { QUICK_REACTIONS } from '../../services/reaction';
@@ -25,14 +26,14 @@ interface MessageContextMenuProps {
   onDeleteForAll: () => void;
   onReaction: (emoji: string) => void;
   onOpenFullPicker: () => void;
+  /** Optional: opens the report flow for the targeted message. */
+  onReport?: () => void;
 }
 
 const MessageContextMenu: React.FC<MessageContextMenuProps> = ({
   isOpen,
   message,
-  // isOwn is part of the public contract but not currently used in
-  // the menu UI — kept so callers can keep passing it.
-  isOwn: _isOwn,
+  isOwn,
   userId,
   onClose,
   onReply,
@@ -42,6 +43,7 @@ const MessageContextMenu: React.FC<MessageContextMenuProps> = ({
   onDeleteForAll,
   onReaction,
   onOpenFullPicker,
+  onReport,
 }) => {
   const { t } = useTranslation();
   const menuRef = useRef<HTMLDivElement>(null);
@@ -115,6 +117,18 @@ const MessageContextMenu: React.FC<MessageContextMenuProps> = ({
       label: t('contextMenu.deleteForAll'),
       icon: trashOutline,
       action: onDeleteForAll,
+      destructive: true,
+    });
+  }
+
+  // Report is shown for messages from someone else. Reporting your
+  // own message would be a no-op, and Apple/Google App Review only
+  // requires the path to exist for messages you didn't write.
+  if (onReport && !isOwn) {
+    actions.push({
+      label: t('report.reportMessage'),
+      icon: flagOutline,
+      action: onReport,
       destructive: true,
     });
   }

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -784,5 +784,50 @@
     "texterRestricted": "Du kan kun dele din position med din teamejer",
     "loading": "Indlæser...",
     "openInMaps": "Åbn i kort"
+  },
+  "report": {
+    "reportMessage": "Rapportér besked",
+    "reportChat": "Rapportér chat",
+    "reportUser": "Rapportér bruger",
+    "title": "Rapportér",
+    "categoryLabel": "Hvorfor rapporterer du?",
+    "descriptionLabel": "Fortæl mere (valgfrit)",
+    "descriptionPlaceholder": "Tilføj kontekst der hjælper os med gennemgangen...",
+    "submit": "Send rapport",
+    "submitting": "Sender...",
+    "success": "Tak — vi har modtaget din rapport.",
+    "errorGeneric": "Noget gik galt. Prøv igen.",
+    "cancel": "Annullér",
+    "categories": {
+      "inappropriate": "Upassende indhold",
+      "harassment": "Chikane eller mobning",
+      "spam": "Spam",
+      "self_harm": "Selvskade",
+      "illegal": "Ulovligt indhold",
+      "other": "Andet"
+    },
+    "team": {
+      "title": "Teamets rapporter",
+      "empty": "Ingen rapporter for dit team endnu.",
+      "filterAll": "Alle",
+      "filterPending": "Afventer",
+      "filterEscalated": "Eskaleret",
+      "openSupport": "Kontakt Zemi support",
+      "markReviewed": "Markér som gennemgået",
+      "markResolved": "Løs",
+      "markDismissed": "Afvis",
+      "reporter": "Rapportør",
+      "target": "Mål",
+      "category": "Kategori",
+      "status": "Status",
+      "description": "Beskrivelse"
+    },
+    "status": {
+      "pending": "Afventer",
+      "reviewed": "Gennemgået",
+      "escalated": "Eskaleret",
+      "resolved": "Løst",
+      "dismissed": "Afvist"
+    }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -784,5 +784,50 @@
     "texterRestricted": "You can only share your location with your team owner",
     "loading": "Loading...",
     "openInMaps": "Open in maps"
+  },
+  "report": {
+    "reportMessage": "Report message",
+    "reportChat": "Report chat",
+    "reportUser": "Report user",
+    "title": "Report",
+    "categoryLabel": "Why are you reporting?",
+    "descriptionLabel": "Tell us more (optional)",
+    "descriptionPlaceholder": "Add context that helps us review...",
+    "submit": "Send report",
+    "submitting": "Sending...",
+    "success": "Thanks — we've received your report.",
+    "errorGeneric": "Something went wrong. Please try again.",
+    "cancel": "Cancel",
+    "categories": {
+      "inappropriate": "Inappropriate content",
+      "harassment": "Harassment or bullying",
+      "spam": "Spam",
+      "self_harm": "Self-harm",
+      "illegal": "Illegal content",
+      "other": "Other"
+    },
+    "team": {
+      "title": "Team reports",
+      "empty": "No reports for your team yet.",
+      "filterAll": "All",
+      "filterPending": "Pending",
+      "filterEscalated": "Escalated",
+      "openSupport": "Contact Zemi support",
+      "markReviewed": "Mark as reviewed",
+      "markResolved": "Resolve",
+      "markDismissed": "Dismiss",
+      "reporter": "Reporter",
+      "target": "Target",
+      "category": "Category",
+      "status": "Status",
+      "description": "Description"
+    },
+    "status": {
+      "pending": "Pending",
+      "reviewed": "Reviewed",
+      "escalated": "Escalated",
+      "resolved": "Resolved",
+      "dismissed": "Dismissed"
+    }
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -784,5 +784,50 @@
     "texterRestricted": "Voit jakaa sijaintisi vain tiimin omistajan kanssa",
     "loading": "Ladataan...",
     "openInMaps": "Avaa kartalla"
+  },
+  "report": {
+    "reportMessage": "Ilmoita viestistä",
+    "reportChat": "Ilmoita chatista",
+    "reportUser": "Ilmoita käyttäjästä",
+    "title": "Ilmoita",
+    "categoryLabel": "Miksi teet ilmoituksen?",
+    "descriptionLabel": "Kerro lisää (valinnainen)",
+    "descriptionPlaceholder": "Lisää tietoja, jotka auttavat meitä tarkistamaan...",
+    "submit": "Lähetä ilmoitus",
+    "submitting": "Lähetetään...",
+    "success": "Kiitos — olemme vastaanottaneet ilmoituksesi.",
+    "errorGeneric": "Jotain meni pieleen. Yritä uudelleen.",
+    "cancel": "Peruuta",
+    "categories": {
+      "inappropriate": "Sopimaton sisältö",
+      "harassment": "Häirintä tai kiusaaminen",
+      "spam": "Roskaposti",
+      "self_harm": "Itsensä vahingoittaminen",
+      "illegal": "Laiton sisältö",
+      "other": "Muu"
+    },
+    "team": {
+      "title": "Tiimin ilmoitukset",
+      "empty": "Ei vielä ilmoituksia tiimillesi.",
+      "filterAll": "Kaikki",
+      "filterPending": "Odottaa",
+      "filterEscalated": "Eskaloitu",
+      "openSupport": "Ota yhteyttä Zemi-tukeen",
+      "markReviewed": "Merkitse tarkistetuksi",
+      "markResolved": "Ratkaise",
+      "markDismissed": "Hylkää",
+      "reporter": "Ilmoittaja",
+      "target": "Kohde",
+      "category": "Luokka",
+      "status": "Tila",
+      "description": "Kuvaus"
+    },
+    "status": {
+      "pending": "Odottaa",
+      "reviewed": "Tarkistettu",
+      "escalated": "Eskaloitu",
+      "resolved": "Ratkaistu",
+      "dismissed": "Hylätty"
+    }
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -784,5 +784,50 @@
     "texterRestricted": "Du kan bare dele posisjonen din med teameieren din",
     "loading": "Laster...",
     "openInMaps": "Åpne i kart"
+  },
+  "report": {
+    "reportMessage": "Rapporter melding",
+    "reportChat": "Rapporter chat",
+    "reportUser": "Rapporter bruker",
+    "title": "Rapporter",
+    "categoryLabel": "Hvorfor rapporterer du?",
+    "descriptionLabel": "Beskriv mer (valgfritt)",
+    "descriptionPlaceholder": "Legg til kontekst som hjelper oss med gjennomgangen...",
+    "submit": "Send rapport",
+    "submitting": "Sender...",
+    "success": "Takk — vi har mottatt rapporten din.",
+    "errorGeneric": "Noe gikk galt. Prøv igjen.",
+    "cancel": "Avbryt",
+    "categories": {
+      "inappropriate": "Upassende innhold",
+      "harassment": "Trakassering eller mobbing",
+      "spam": "Spam",
+      "self_harm": "Selvskading",
+      "illegal": "Ulovlig innhold",
+      "other": "Annet"
+    },
+    "team": {
+      "title": "Teamets rapporter",
+      "empty": "Ingen rapporter for teamet ditt ennå.",
+      "filterAll": "Alle",
+      "filterPending": "Venter",
+      "filterEscalated": "Eskalert",
+      "openSupport": "Kontakt Zemi support",
+      "markReviewed": "Marker som gjennomgått",
+      "markResolved": "Løs",
+      "markDismissed": "Avvis",
+      "reporter": "Rapportør",
+      "target": "Mål",
+      "category": "Kategori",
+      "status": "Status",
+      "description": "Beskrivelse"
+    },
+    "status": {
+      "pending": "Venter",
+      "reviewed": "Gjennomgått",
+      "escalated": "Eskalert",
+      "resolved": "Løst",
+      "dismissed": "Avvist"
+    }
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -790,5 +790,50 @@
     "texterRestricted": "Du kan bara dela din position med din teamägare",
     "loading": "Laddar...",
     "openInMaps": "Öppna i karta"
+  },
+  "report": {
+    "reportMessage": "Rapportera meddelandet",
+    "reportChat": "Rapportera chatten",
+    "reportUser": "Rapportera användaren",
+    "title": "Rapportera",
+    "categoryLabel": "Varför rapporterar du?",
+    "descriptionLabel": "Beskriv mer (valfritt)",
+    "descriptionPlaceholder": "Lägg till information som hjälper oss att granska...",
+    "submit": "Skicka rapport",
+    "submitting": "Skickar...",
+    "success": "Tack — vi har tagit emot din rapport.",
+    "errorGeneric": "Något gick fel. Försök igen.",
+    "cancel": "Avbryt",
+    "categories": {
+      "inappropriate": "Olämpligt innehåll",
+      "harassment": "Trakasserier eller mobbning",
+      "spam": "Spam",
+      "self_harm": "Självskadebeteende",
+      "illegal": "Olagligt innehåll",
+      "other": "Annat"
+    },
+    "team": {
+      "title": "Teamets rapporter",
+      "empty": "Inga rapporter för ditt team ännu.",
+      "filterAll": "Alla",
+      "filterPending": "Väntande",
+      "filterEscalated": "Eskalerade",
+      "openSupport": "Kontakta Zemi support",
+      "markReviewed": "Markera som granskad",
+      "markResolved": "Lös",
+      "markDismissed": "Avvisa",
+      "reporter": "Rapporterare",
+      "target": "Mål",
+      "category": "Kategori",
+      "status": "Status",
+      "description": "Beskrivning"
+    },
+    "status": {
+      "pending": "Väntande",
+      "reviewed": "Granskad",
+      "escalated": "Eskalerad",
+      "resolved": "Löst",
+      "dismissed": "Avvisad"
+    }
   }
 }

--- a/src/pages/ChatInfo.tsx
+++ b/src/pages/ChatInfo.tsx
@@ -25,6 +25,7 @@ import { usePresence } from '../hooks/usePresence';
 import { type User } from '../types/database';
 import { getAvatarColor, getInitial } from '../utils/userDisplay';
 import { useSignedMediaUrl } from '../hooks/useSignedMediaUrl';
+import ReportButton from '../components/ReportButton';
 
 /**
  * Thumbnail that resolves a chat-media storage path to a signed URL.
@@ -259,6 +260,23 @@ const ChatInfo: React.FC = () => {
                 <IonIcon icon={logOutOutline} />
                 {t('chatInfo.leaveGroup')}
               </button>
+            </div>
+          )}
+
+          {/* Report section — visible to all members. Apple/Google
+              App Review require a report path for any UGC. */}
+          {chat && (
+            <div className="info-section" style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              {chat.is_group ? (
+                <ReportButton target={{ kind: 'chat', chatId: chat.id }} variant="button" />
+              ) : (
+                <>
+                  <ReportButton target={{ kind: 'chat', chatId: chat.id }} variant="button" />
+                  {otherUser && (
+                    <ReportButton target={{ kind: 'user', userId: otherUser.id }} variant="button" />
+                  )}
+                </>
+              )}
             </div>
           )}
         </div>

--- a/src/pages/ChatView.tsx
+++ b/src/pages/ChatView.tsx
@@ -84,6 +84,7 @@ import { usePresence } from '../hooks/usePresence';
 import { canShareLocation } from '../services/location';
 import LocationPicker from '../components/chat/LocationPicker';
 import { MAX_GROUP_CALL_PARTICIPANTS } from '../types/call';
+import ReportButton from '../components/ReportButton';
 
 const ChatView: React.FC = () => {
   const { t } = useTranslation();
@@ -131,6 +132,10 @@ const ChatView: React.FC = () => {
 
   // Context menu state
   const [contextMenuTarget, setContextMenuTarget] = useState<MessageWithSender | null>(null);
+
+  // Report flow state — set when the user picks "Report" from the
+  // long-press context menu. Drives the modal in <ReportButton/>.
+  const [reportingMessageId, setReportingMessageId] = useState<string | null>(null);
 
   // Edit mode state
   const [editingMessage, setEditingMessage] = useState<MessageWithSender | null>(null);
@@ -1193,7 +1198,21 @@ const ChatView: React.FC = () => {
         onDeleteForAll={handleDeleteForAll}
         onReaction={handleSelectReaction}
         onOpenFullPicker={handleOpenFullEmojiPicker}
+        onReport={() => {
+          if (contextMenuTarget) {
+            setReportingMessageId(contextMenuTarget.id);
+          }
+          setContextMenuTarget(null);
+        }}
       />
+
+      {reportingMessageId && (
+        <ReportButton
+          target={{ kind: 'message', messageId: reportingMessageId }}
+          forceOpen
+          onClose={() => setReportingMessageId(null)}
+        />
+      )}
 
       <ForwardPicker
         isOpen={showForwardPicker}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -29,6 +29,7 @@ import {
   eyeOutline,
   checkmarkCircleOutline,
   mailOutline,
+  flagOutline,
 } from 'ionicons/icons';
 import { useAuthContext } from '../contexts/AuthContext';
 import { getTeamMembers } from '../services/members';
@@ -192,6 +193,12 @@ const Dashboard: React.FC = () => {
                 <IonLabel>
                   <h3>{t('invite.title')}</h3>
                   <p>{t('dashboard.inviteSuperDescription')}</p>
+                </IonLabel>
+              </IonItem>
+              <IonItem button detail routerLink="/team-reports" className="action-item">
+                <IonIcon icon={flagOutline} slot="start" className="action-icon" />
+                <IonLabel>
+                  <h3>{t('report.team.title')}</h3>
                 </IonLabel>
               </IonItem>
             </IonList>

--- a/src/pages/TeamReports.tsx
+++ b/src/pages/TeamReports.tsx
@@ -1,0 +1,305 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  IonPage,
+  IonContent,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonButtons,
+  IonBackButton,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonBadge,
+  IonSegment,
+  IonSegmentButton,
+  IonRefresher,
+  IonRefresherContent,
+  IonModal,
+  IonButton,
+  IonText,
+  IonNote,
+  IonIcon,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import { flagOutline, mailOutline } from 'ionicons/icons';
+import {
+  getTeamReports,
+  setReportStatus,
+  type ReportWithReporter,
+} from '../services/report';
+import {
+  ReportStatus,
+  ReportCategory,
+  UserRole,
+} from '../types/database';
+import { useAuthContext } from '../contexts/AuthContext';
+import { Redirect } from 'react-router-dom';
+
+type StatusFilter = 'all' | 'pending' | 'escalated';
+
+const TeamReports: React.FC = () => {
+  const { t } = useTranslation();
+  const { profile } = useAuthContext();
+
+  const [reports, setReports] = useState<ReportWithReporter[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [categoryFilter, setCategoryFilter] = useState<ReportCategory | 'all'>(
+    'all',
+  );
+  const [selected, setSelected] = useState<ReportWithReporter | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    const opts: Parameters<typeof getTeamReports>[0] = {};
+    if (statusFilter !== 'all') {
+      opts.status =
+        statusFilter === 'pending'
+          ? ReportStatus.PENDING
+          : ReportStatus.ESCALATED;
+    }
+    if (categoryFilter !== 'all') opts.category = categoryFilter;
+    const { reports: rows } = await getTeamReports(opts);
+    setReports(rows);
+    setIsLoading(false);
+  }, [statusFilter, categoryFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Owner-only page. If a non-owner somehow lands here, kick them
+  // back to the dashboard rather than rendering an empty list.
+  if (profile && profile.role !== UserRole.OWNER) {
+    return <Redirect to="/dashboard" />;
+  }
+
+  const handleRefresh = async (e: CustomEvent<RefresherEventDetail>) => {
+    await load();
+    e.detail.complete();
+  };
+
+  const setStatus = async (
+    report: ReportWithReporter,
+    status:
+      | ReportStatus.REVIEWED
+      | ReportStatus.RESOLVED
+      | ReportStatus.DISMISSED,
+  ) => {
+    await setReportStatus(report.id, status);
+    setSelected(null);
+    await load();
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/dashboard" />
+          </IonButtons>
+          <IonTitle>{t('report.team.title')}</IonTitle>
+        </IonToolbar>
+        <IonToolbar>
+          <IonSegment
+            value={statusFilter}
+            onIonChange={(e) =>
+              setStatusFilter((e.detail.value as StatusFilter) ?? 'all')
+            }
+          >
+            <IonSegmentButton value="all">
+              <IonLabel>{t('report.team.filterAll')}</IonLabel>
+            </IonSegmentButton>
+            <IonSegmentButton value="pending">
+              <IonLabel>{t('report.team.filterPending')}</IonLabel>
+            </IonSegmentButton>
+            <IonSegmentButton value="escalated">
+              <IonLabel>{t('report.team.filterEscalated')}</IonLabel>
+            </IonSegmentButton>
+          </IonSegment>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+          <IonRefresherContent />
+        </IonRefresher>
+
+        <div style={{ padding: '0.5rem 1rem' }}>
+          <select
+            value={categoryFilter}
+            onChange={(e) =>
+              setCategoryFilter(
+                (e.target.value as ReportCategory | 'all') ?? 'all',
+              )
+            }
+            style={{
+              width: '100%',
+              padding: '0.5rem',
+              borderRadius: '0.5rem',
+              border: '1px solid var(--ion-color-medium)',
+              background: 'transparent',
+              color: 'var(--ion-text-color)',
+            }}
+          >
+            <option value="all">{t('report.team.category')}: {t('report.team.filterAll')}</option>
+            {Object.values(ReportCategory).map((c) => (
+              <option key={c} value={c}>
+                {t(`report.categories.${c}`)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {isLoading ? null : reports.length === 0 ? (
+          <div style={{ padding: '2rem', textAlign: 'center' }}>
+            <IonIcon
+              icon={flagOutline}
+              style={{ fontSize: '3rem', color: 'var(--ion-color-medium)' }}
+            />
+            <p>{t('report.team.empty')}</p>
+          </div>
+        ) : (
+          <IonList>
+            {reports.map((r) => (
+              <IonItem key={r.id} button onClick={() => setSelected(r)}>
+                <IonLabel>
+                  <h3>
+                    {r.category
+                      ? t(`report.categories.${r.category}`)
+                      : t('report.categories.other')}
+                  </h3>
+                  <p>
+                    {r.target_type ? `${r.target_type}` : ''}
+                    {r.reporter?.display_name
+                      ? ` · ${r.reporter.display_name}`
+                      : ''}
+                  </p>
+                  <IonNote color="medium">
+                    {new Date(r.created_at).toLocaleString()}
+                  </IonNote>
+                </IonLabel>
+                <IonBadge
+                  slot="end"
+                  color={
+                    r.status === ReportStatus.ESCALATED
+                      ? 'danger'
+                      : r.status === ReportStatus.PENDING
+                        ? 'warning'
+                        : 'medium'
+                  }
+                >
+                  {t(`report.status.${r.status}`)}
+                </IonBadge>
+              </IonItem>
+            ))}
+          </IonList>
+        )}
+
+        <IonModal isOpen={!!selected} onDidDismiss={() => setSelected(null)}>
+          <IonHeader>
+            <IonToolbar>
+              <IonTitle>{t('report.title')}</IonTitle>
+              <IonButtons slot="end">
+                <IonButton onClick={() => setSelected(null)}>
+                  {t('report.cancel')}
+                </IonButton>
+              </IonButtons>
+            </IonToolbar>
+          </IonHeader>
+          <IonContent className="ion-padding">
+            {selected && (
+              <>
+                <p>
+                  <strong>{t('report.team.reporter')}:</strong>{' '}
+                  {selected.reporter?.display_name ||
+                    selected.reporter?.zemi_number ||
+                    selected.reporter_id}
+                </p>
+                <p>
+                  <strong>{t('report.team.target')}:</strong>{' '}
+                  {selected.target_type ?? 'unknown'}{' '}
+                  {selected.reported_user?.display_name
+                    ? `(${selected.reported_user.display_name})`
+                    : ''}
+                </p>
+                <p>
+                  <strong>{t('report.team.category')}:</strong>{' '}
+                  {selected.category
+                    ? t(`report.categories.${selected.category}`)
+                    : '-'}
+                </p>
+                <p>
+                  <strong>{t('report.team.status')}:</strong>{' '}
+                  {t(`report.status.${selected.status}`)}
+                </p>
+                {selected.description && (
+                  <>
+                    <p>
+                      <strong>{t('report.team.description')}:</strong>
+                    </p>
+                    <IonText>
+                      <p style={{ whiteSpace: 'pre-wrap' }}>
+                        {selected.description}
+                      </p>
+                    </IonText>
+                  </>
+                )}
+
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '0.5rem',
+                    marginTop: '1.5rem',
+                  }}
+                >
+                  <IonButton
+                    expand="block"
+                    fill="outline"
+                    href="mailto:support@zemichat.com?subject=Zemichat%20moderation"
+                  >
+                    <IonIcon slot="start" icon={mailOutline} />
+                    {t('report.team.openSupport')}
+                  </IonButton>
+
+                  {selected.status !== ReportStatus.REVIEWED && (
+                    <IonButton
+                      expand="block"
+                      onClick={() => setStatus(selected, ReportStatus.REVIEWED)}
+                    >
+                      {t('report.team.markReviewed')}
+                    </IonButton>
+                  )}
+                  {selected.status !== ReportStatus.RESOLVED && (
+                    <IonButton
+                      expand="block"
+                      color="success"
+                      onClick={() => setStatus(selected, ReportStatus.RESOLVED)}
+                    >
+                      {t('report.team.markResolved')}
+                    </IonButton>
+                  )}
+                  {selected.status !== ReportStatus.DISMISSED && (
+                    <IonButton
+                      expand="block"
+                      color="medium"
+                      onClick={() =>
+                        setStatus(selected, ReportStatus.DISMISSED)
+                      }
+                    >
+                      {t('report.team.markDismissed')}
+                    </IonButton>
+                  )}
+                </div>
+              </>
+            )}
+          </IonContent>
+        </IonModal>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default TeamReports;

--- a/src/services/report.ts
+++ b/src/services/report.ts
@@ -1,0 +1,283 @@
+import { supabase } from './supabase';
+import {
+  type Report,
+  type User,
+  ReportCategory,
+  ReportStatus,
+  ReportTargetType,
+  UserRole,
+} from '../types/database';
+
+// ============================================================
+// Types
+// ============================================================
+
+const MAX_DESCRIPTION_LENGTH = 2000;
+
+export interface ReportWithReporter extends Report {
+  reporter: Pick<User, 'id' | 'display_name' | 'zemi_number'> | null;
+  reported_user: Pick<User, 'id' | 'display_name' | 'zemi_number'> | null;
+}
+
+interface CreateReportArgs {
+  category: ReportCategory;
+  description?: string;
+  reportedUserId?: string;
+  reportedMessageId?: string;
+  reportedChatId?: string;
+}
+
+// ============================================================
+// Internal helpers
+// ============================================================
+
+/**
+ * Map a ReportCategory to a short human-readable string for the legacy
+ * `reason` column. Older clients still read this; older rows still
+ * write here. Keep in sync with i18n keys when those land.
+ */
+function categoryLabel(category: ReportCategory): string {
+  switch (category) {
+    case ReportCategory.INAPPROPRIATE:
+      return 'Inappropriate content';
+    case ReportCategory.HARASSMENT:
+      return 'Harassment';
+    case ReportCategory.SPAM:
+      return 'Spam';
+    case ReportCategory.SELF_HARM:
+      return 'Self-harm';
+    case ReportCategory.ILLEGAL:
+      return 'Illegal content';
+    case ReportCategory.OTHER:
+      return 'Other';
+  }
+}
+
+async function createReport(args: CreateReportArgs): Promise<{
+  report: Report | null;
+  error: Error | null;
+}> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { report: null, error: new Error('Not authenticated') };
+  }
+
+  if (
+    !args.reportedUserId &&
+    !args.reportedMessageId &&
+    !args.reportedChatId
+  ) {
+    return {
+      report: null,
+      error: new Error('Must report a user, a message, or a chat'),
+    };
+  }
+
+  const description =
+    typeof args.description === 'string'
+      ? args.description.trim().slice(0, MAX_DESCRIPTION_LENGTH)
+      : null;
+
+  const { data, error } = await supabase
+    .from('reports')
+    .insert({
+      reporter_id: user.id,
+      reported_user_id: args.reportedUserId ?? null,
+      reported_message_id: args.reportedMessageId ?? null,
+      reported_chat_id: args.reportedChatId ?? null,
+      category: args.category,
+      description: description && description.length > 0 ? description : null,
+      // Keep legacy `reason` populated so older clients / mail templates
+      // still show something readable.
+      reason: categoryLabel(args.category),
+      status: ReportStatus.PENDING,
+    } as never)
+    .select()
+    .single();
+
+  if (error) {
+    return { report: null, error: new Error(error.message) };
+  }
+
+  // Fire-and-forget: notify support / Owner about the new report. The
+  // edge function applies its own auth + counts so it's safe to skip
+  // on transient errors.
+  supabase.functions
+    .invoke('report-handler', { body: { reportId: (data as { id: string }).id } })
+    .catch(() => {
+      // Non-critical: notification failure must not break the user flow.
+    });
+
+  return { report: data as unknown as Report, error: null };
+}
+
+// ============================================================
+// Public API — one entry point per target type, mirroring the PRD.
+// ============================================================
+
+export async function reportMessage(
+  messageId: string,
+  category: ReportCategory,
+  description?: string,
+): Promise<{ report: Report | null; error: Error | null }> {
+  return createReport({
+    category,
+    description,
+    reportedMessageId: messageId,
+  });
+}
+
+export async function reportChat(
+  chatId: string,
+  category: ReportCategory,
+  description?: string,
+): Promise<{ report: Report | null; error: Error | null }> {
+  return createReport({
+    category,
+    description,
+    reportedChatId: chatId,
+  });
+}
+
+export async function reportUser(
+  userId: string,
+  category: ReportCategory,
+  description?: string,
+): Promise<{ report: Report | null; error: Error | null }> {
+  return createReport({
+    category,
+    description,
+    reportedUserId: userId,
+  });
+}
+
+// ============================================================
+// Reads
+// ============================================================
+
+/**
+ * Reports submitted by the currently signed-in user.
+ */
+export async function getMyReports(): Promise<{
+  reports: Report[];
+  error: Error | null;
+}> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { reports: [], error: new Error('Not authenticated') };
+  }
+
+  const { data, error } = await supabase
+    .from('reports')
+    .select('*')
+    .eq('reporter_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return { reports: [], error: new Error(error.message) };
+  }
+  return { reports: (data ?? []) as unknown as Report[], error: null };
+}
+
+/**
+ * All reports involving the Owner's team — either authored by their
+ * Texters/Supers or targeting them. Owner-only. RLS still enforces the
+ * boundary; this just performs the team-scoped fetch.
+ */
+export async function getTeamReports(options?: {
+  status?: ReportStatus;
+  category?: ReportCategory;
+  targetType?: ReportTargetType;
+  limit?: number;
+}): Promise<{
+  reports: ReportWithReporter[];
+  error: Error | null;
+}> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { reports: [], error: new Error('Not authenticated') };
+  }
+
+  const { data: me, error: meError } = await supabase
+    .from('users')
+    .select('team_id, role')
+    .eq('id', user.id)
+    .maybeSingle();
+  if (meError || !me) {
+    return { reports: [], error: new Error('Could not load user') };
+  }
+  const meTyped = me as unknown as { team_id: string; role: UserRole };
+  if (meTyped.role !== UserRole.OWNER) {
+    return { reports: [], error: new Error('Only owners can list team reports') };
+  }
+
+  let query = supabase
+    .from('reports')
+    .select(
+      `
+      *,
+      reporter:reporter_id (id, display_name, zemi_number),
+      reported_user:reported_user_id (id, display_name, zemi_number)
+      `,
+    )
+    .order('created_at', { ascending: false })
+    .limit(options?.limit ?? 100);
+
+  if (options?.status) query = query.eq('status', options.status);
+  if (options?.category) query = query.eq('category', options.category);
+  if (options?.targetType) query = query.eq('target_type', options.targetType);
+
+  const { data, error } = await query;
+  if (error) {
+    return { reports: [], error: new Error(error.message) };
+  }
+  return {
+    reports: (data ?? []) as unknown as ReportWithReporter[],
+    error: null,
+  };
+}
+
+/**
+ * Owner moves a report to one of the terminal statuses. The trigger
+ * fills in reviewed_at automatically.
+ */
+export async function setReportStatus(
+  reportId: string,
+  status: ReportStatus.REVIEWED | ReportStatus.RESOLVED | ReportStatus.DISMISSED,
+): Promise<{ error: Error | null }> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: new Error('Not authenticated') };
+  }
+
+  const { error } = await supabase
+    .from('reports')
+    .update({ status, reviewed_by: user.id } as never)
+    .eq('id', reportId);
+
+  if (error) {
+    return { error: new Error(error.message) };
+  }
+  return { error: null };
+}
+
+/**
+ * Stable list of categories for the UI (used by the report modal).
+ * Order is intentional: most-likely-used first, "other" last.
+ */
+export const REPORT_CATEGORY_ORDER: ReportCategory[] = [
+  ReportCategory.INAPPROPRIATE,
+  ReportCategory.HARASSMENT,
+  ReportCategory.SPAM,
+  ReportCategory.SELF_HARM,
+  ReportCategory.ILLEGAL,
+  ReportCategory.OTHER,
+];

--- a/src/tests/rls/reports.rls.test.ts
+++ b/src/tests/rls/reports.rls.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll } from 'vitest';
+import { describe, it, beforeAll, expect } from 'vitest';
 import {
   getTestWorld,
   expectRows,
@@ -197,6 +197,59 @@ describe('reports RLS', () => {
       await w.adminClient.from('reports').delete().eq('id', report!.id);
     });
 
+    it('Owner can move a report to resolved/dismissed', async () => {
+      const { data: report } = await w.adminClient
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.texter.id,
+          reported_user_id: w.team2.texter.id,
+          reason: 'Test',
+          category: 'spam',
+          status: 'pending',
+        })
+        .select()
+        .single();
+
+      const res1 = await w.team1.owner.client
+        .from('reports')
+        .update({ status: 'resolved', reviewed_by: w.team1.owner.id })
+        .eq('id', report!.id)
+        .select();
+      expectRows(res1, 1);
+
+      const res2 = await w.team1.owner.client
+        .from('reports')
+        .update({ status: 'dismissed', reviewed_by: w.team1.owner.id })
+        .eq('id', report!.id)
+        .select();
+      expectRows(res2, 1);
+
+      await w.adminClient.from('reports').delete().eq('id', report!.id);
+    });
+
+    it('Owner cannot rewrite a report back to pending via WITH CHECK', async () => {
+      const { data: report } = await w.adminClient
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.texter.id,
+          reported_user_id: w.team2.texter.id,
+          reason: 'Test',
+          status: 'reviewed',
+        })
+        .select()
+        .single();
+
+      const res = await w.team1.owner.client
+        .from('reports')
+        .update({ status: 'pending', reviewed_by: w.team1.owner.id })
+        .eq('id', report!.id)
+        .select();
+      // Either RLS-rejected outright or zero rows updated.
+      expectBlocked(res);
+
+      await w.adminClient.from('reports').delete().eq('id', report!.id);
+    });
+
     it('Non-owner cannot update report', async () => {
       const { data: report } = await w.adminClient
         .from('reports')
@@ -217,6 +270,151 @@ describe('reports RLS', () => {
       expectBlocked(res);
 
       await w.adminClient.from('reports').delete().eq('id', report!.id);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // CATEGORY + DESCRIPTION + CHAT TARGET (extended schema)
+  // ------------------------------------------------------------------
+  describe('extended fields', () => {
+    it('User can submit a report with category + description', async () => {
+      const res = await w.team1.texter.client
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.texter.id,
+          reported_user_id: w.team2.texter.id,
+          category: 'harassment',
+          description: 'They keep calling me names',
+          reason: 'Harassment',
+          status: 'pending',
+        })
+        .select()
+        .single();
+      expectSuccess(res);
+      if (res.data) {
+        // target_type generated column should reflect the user target
+        // unless message > chat > user wins (here only user is set).
+        expect((res.data as { target_type: string | null }).target_type).toBe('user');
+        await w.adminClient.from('reports').delete().eq('id', res.data.id);
+      }
+    });
+
+    it('Reporter can submit a chat-targeted report', async () => {
+      const res = await w.team1.texter.client
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.texter.id,
+          reported_chat_id: w.chats.texterToTexter,
+          category: 'spam',
+          reason: 'Spam',
+          status: 'pending',
+        })
+        .select()
+        .single();
+      expectSuccess(res);
+      if (res.data) {
+        expect((res.data as { target_type: string | null }).target_type).toBe('chat');
+        await w.adminClient.from('reports').delete().eq('id', res.data.id);
+      }
+    });
+
+    it('Description longer than 2000 chars is rejected', async () => {
+      const huge = 'x'.repeat(2001);
+      const res = await w.team1.texter.client
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.texter.id,
+          reported_user_id: w.team2.texter.id,
+          category: 'other',
+          description: huge,
+          reason: 'Other',
+          status: 'pending',
+        })
+        .select()
+        .single();
+      expectRLSError(res);
+    });
+
+    it('Cannot insert a report with NO target at all', async () => {
+      const res = await w.team1.texter.client
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.texter.id,
+          category: 'other',
+          reason: 'Other',
+          status: 'pending',
+        })
+        .select()
+        .single();
+      expectRLSError(res);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // ESCALATION (3-distinct-reporters threshold)
+  // ------------------------------------------------------------------
+  describe('escalation trigger', () => {
+    it('Three distinct reporters against the same user flips them all to escalated', async () => {
+      // Use 3 different reporters: texter1, super1, owner1 (all in
+      // team1) reporting team2.texter. The trigger counts distinct
+      // reporter_id values, so we need three different users.
+      const inserted: string[] = [];
+
+      const res1 = await w.adminClient
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.texter.id,
+          reported_user_id: w.team2.texter.id,
+          category: 'spam',
+          reason: 'Spam',
+          status: 'pending',
+        })
+        .select()
+        .single();
+      if (res1.data) inserted.push(res1.data.id);
+
+      const res2 = await w.adminClient
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.super.id,
+          reported_user_id: w.team2.texter.id,
+          category: 'spam',
+          reason: 'Spam',
+          status: 'pending',
+        })
+        .select()
+        .single();
+      if (res2.data) inserted.push(res2.data.id);
+
+      const res3 = await w.adminClient
+        .from('reports')
+        .insert({
+          reporter_id: w.team1.owner.id,
+          reported_user_id: w.team2.texter.id,
+          category: 'spam',
+          reason: 'Spam',
+          status: 'pending',
+        })
+        .select()
+        .single();
+      if (res3.data) inserted.push(res3.data.id);
+
+      // After the third insert, all reports for team2.texter should be
+      // escalated.
+      const { data: rows } = await w.adminClient
+        .from('reports')
+        .select('id, status, escalated_at')
+        .eq('reported_user_id', w.team2.texter.id);
+      expect(rows).not.toBeNull();
+      for (const row of rows ?? []) {
+        const r = row as { status: string; escalated_at: string | null };
+        expect(r.status).toBe('escalated');
+        expect(r.escalated_at).not.toBeNull();
+      }
+
+      for (const id of inserted) {
+        await w.adminClient.from('reports').delete().eq('id', id);
+      }
     });
   });
 });

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -42,6 +42,23 @@ export enum ReportStatus {
   PENDING = 'pending',
   REVIEWED = 'reviewed',
   ESCALATED = 'escalated',
+  RESOLVED = 'resolved',
+  DISMISSED = 'dismissed',
+}
+
+export enum ReportCategory {
+  INAPPROPRIATE = 'inappropriate',
+  HARASSMENT = 'harassment',
+  SPAM = 'spam',
+  SELF_HARM = 'self_harm',
+  ILLEGAL = 'illegal',
+  OTHER = 'other',
+}
+
+export enum ReportTargetType {
+  MESSAGE = 'message',
+  CHAT = 'chat',
+  USER = 'user',
 }
 
 export enum CallType {
@@ -243,9 +260,15 @@ export interface Report {
   reporter_id: string;
   reported_user_id: string | null;
   reported_message_id: string | null;
+  reported_chat_id: string | null;
+  /** Generated column: 'message' | 'chat' | 'user' depending on which FK is set. */
+  target_type: ReportTargetType | null;
   reason: string | null;
+  category: ReportCategory | null;
+  description: string | null;
   status: ReportStatus;
   reviewed_by: string | null;
+  reviewed_at: string | null;
   escalated_at: string | null;
   created_at: string;
 }
@@ -580,6 +603,7 @@ export interface Database {
       friendship_status: FriendshipStatus;
       message_type: MessageType;
       report_status: ReportStatus;
+      report_category: ReportCategory;
       call_type: CallType;
       call_status: CallStatus;
       signal_type: SignalType;

--- a/supabase/functions/report-handler/index.ts
+++ b/supabase/functions/report-handler/index.ts
@@ -1,0 +1,312 @@
+// Edge function: report-handler
+//
+// Called fire-and-forget from src/services/report.ts after a new
+// `reports` row is inserted. Responsibilities:
+//
+//   1. Verify the caller actually authored the report (defence in
+//      depth — RLS already restricts INSERT, but we re-check before
+//      acting on it).
+//   2. Count distinct reporters against the same target. If we have
+//      >= 3, mail support@zemichat.com so a human can review.
+//   3. Push the team Owner when their team's threshold is hit, so
+//      they know to take action / contact Zemi support.
+//
+// No state is mutated by this function — escalation itself is owned
+// by the AFTER INSERT trigger `check_report_escalation()` in
+// 20260427160000_extend_reports_for_moderation.sql. We only read +
+// notify here so RLS / DB stay the source of truth.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getCorsHeaders, corsPreflightResponse } from '../_shared/cors.ts';
+import { checkRateLimit, rateLimitResponse } from '../_shared/rate-limit.ts';
+import { escapeHtml } from '../_shared/escape-html.ts';
+
+const ESCALATION_THRESHOLD = 3;
+const SUPPORT_INBOX = 'support@zemichat.com';
+
+interface ReportRow {
+  id: string;
+  reporter_id: string;
+  reported_user_id: string | null;
+  reported_message_id: string | null;
+  reported_chat_id: string | null;
+  target_type: 'message' | 'chat' | 'user' | null;
+  category: string | null;
+  description: string | null;
+  reason: string | null;
+  status: string;
+  created_at: string;
+}
+
+interface UserRow {
+  id: string;
+  team_id: string;
+  display_name: string | null;
+  zemi_number: string | null;
+  role: string;
+}
+
+serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
+
+  if (req.method === 'OPTIONS') {
+    return corsPreflightResponse(req);
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+    const resendApiKey = Deno.env.get('RESEND_API_KEY') ?? '';
+
+    const userClient = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const {
+      data: { user },
+      error: authError,
+    } = await userClient.auth.getUser();
+
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const serviceClient = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Modest rate limit — a single client should not invoke this more
+    // than ~5 times per minute under any legitimate flow.
+    const rl = await checkRateLimit(serviceClient, 'report-handler', user.id, 5);
+    if (!rl.allowed) {
+      return rateLimitResponse(corsHeaders, rl.retryAfterSeconds);
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const reportId = typeof body.reportId === 'string' ? body.reportId : '';
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(reportId)) {
+      return new Response(JSON.stringify({ error: 'Invalid reportId' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Service-role read so we don't depend on the caller's RLS view.
+    const { data: report, error: reportError } = await serviceClient
+      .from('reports')
+      .select('*')
+      .eq('id', reportId)
+      .maybeSingle();
+
+    if (reportError || !report) {
+      return new Response(JSON.stringify({ error: 'Report not found' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+    const reportRow = report as ReportRow;
+
+    // Defence in depth: only the reporter (or an Owner who is
+    // tracking it) may trigger this notification flow.
+    if (reportRow.reporter_id !== user.id) {
+      return new Response(JSON.stringify({ error: 'Forbidden' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Count distinct reporters against the same target. Match the
+    // DB trigger's logic so Edge + DB agree on when to escalate.
+    let countQuery = serviceClient
+      .from('reports')
+      .select('reporter_id', { count: 'exact', head: false });
+
+    if (reportRow.reported_message_id) {
+      countQuery = countQuery.eq('reported_message_id', reportRow.reported_message_id);
+    } else if (reportRow.reported_chat_id) {
+      countQuery = countQuery.eq('reported_chat_id', reportRow.reported_chat_id);
+    } else if (reportRow.reported_user_id) {
+      countQuery = countQuery.eq('reported_user_id', reportRow.reported_user_id);
+    } else {
+      // Nothing to count — bail out cleanly.
+      return new Response(JSON.stringify({ ok: true, escalated: false }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+    const { data: rows, error: countError } = await countQuery
+      .in('status', ['pending', 'reviewed', 'escalated'])
+      .limit(1000);
+    if (countError) {
+      console.error('report-handler count error:', countError.message);
+      return new Response(JSON.stringify({ error: 'Internal error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+    const distinctReporters = new Set(
+      (rows ?? []).map((r) => (r as { reporter_id: string }).reporter_id),
+    );
+    const escalated = distinctReporters.size >= ESCALATION_THRESHOLD;
+
+    if (!escalated) {
+      return new Response(
+        JSON.stringify({ ok: true, escalated: false, reporters: distinctReporters.size }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    // ----------------------------------------------------------------
+    // Threshold met. Email support and (best effort) push the Owner.
+    // ----------------------------------------------------------------
+    let reportedUser: UserRow | null = null;
+    if (reportRow.reported_user_id) {
+      const { data } = await serviceClient
+        .from('users')
+        .select('id, team_id, display_name, zemi_number, role')
+        .eq('id', reportRow.reported_user_id)
+        .maybeSingle();
+      reportedUser = (data as UserRow | null) ?? null;
+    }
+
+    let reportedChatTeamId: string | null = null;
+    if (reportRow.reported_chat_id) {
+      // Find a Texter member of the chat — that gives us a team to
+      // notify the Owner of (matches the RLS policy we wrote).
+      const { data: members } = await serviceClient
+        .from('chat_members')
+        .select('user_id')
+        .eq('chat_id', reportRow.reported_chat_id)
+        .is('left_at', null);
+      const memberIds = (members ?? []).map((m) => (m as { user_id: string }).user_id);
+      if (memberIds.length > 0) {
+        const { data: usersInChat } = await serviceClient
+          .from('users')
+          .select('id, team_id, role')
+          .in('id', memberIds);
+        const texter = (usersInChat ?? []).find(
+          (u) => (u as { role: string }).role === 'texter',
+        ) as UserRow | undefined;
+        if (texter) reportedChatTeamId = texter.team_id;
+      }
+    }
+
+    if (resendApiKey) {
+      const safeId = escapeHtml(reportRow.id);
+      const safeCategory = escapeHtml(reportRow.category ?? reportRow.reason ?? 'unknown');
+      const safeDescription = escapeHtml(reportRow.description ?? '').replace(
+        /\n/g,
+        '<br/>',
+      );
+      const safeTargetType = escapeHtml(reportRow.target_type ?? 'unknown');
+      const safeTargetId = escapeHtml(
+        reportRow.reported_message_id ??
+          reportRow.reported_chat_id ??
+          reportRow.reported_user_id ??
+          '',
+      );
+      const safeReportedDisplay = escapeHtml(
+        reportedUser?.display_name ?? reportedUser?.zemi_number ?? '',
+      );
+
+      const html = `
+<h2>Zemichat — report threshold reached</h2>
+<p>A target has crossed the ${ESCALATION_THRESHOLD}-distinct-reporter threshold.</p>
+<table cellpadding="6" style="border-collapse:collapse;">
+  <tr><td><strong>Triggering report id:</strong></td><td>${safeId}</td></tr>
+  <tr><td><strong>Target type:</strong></td><td>${safeTargetType}</td></tr>
+  <tr><td><strong>Target id:</strong></td><td>${safeTargetId}</td></tr>
+  <tr><td><strong>Category:</strong></td><td>${safeCategory}</td></tr>
+  <tr><td><strong>Distinct reporters:</strong></td><td>${distinctReporters.size}</td></tr>
+  ${reportedUser ? `<tr><td><strong>Reported user:</strong></td><td>${safeReportedDisplay}</td></tr>` : ''}
+</table>
+${safeDescription ? `<p><strong>Latest description:</strong></p><p>${safeDescription}</p>` : ''}
+<p style="color:#888;font-size:12px;">
+  This message is generated automatically. The DB trigger has already
+  flipped affected reports to <code>escalated</code>.
+</p>`.trim();
+
+      const subject = `[Zemichat] Reports escalated for ${reportRow.target_type ?? 'target'}`
+        .replace(/[\r\n]+/g, ' ');
+
+      const resendResp = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${resendApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: 'Zemichat Moderation <noreply@zemichat.com>',
+          to: SUPPORT_INBOX,
+          subject,
+          html,
+        }),
+      });
+      if (!resendResp.ok) {
+        const txt = await resendResp.text();
+        console.error('report-handler Resend error:', txt);
+        // Fall through — we still want to push the Owner.
+      }
+    } else {
+      console.warn('RESEND_API_KEY missing — escalation email skipped');
+    }
+
+    // Best-effort push to the relevant Team Owner.
+    const ownerTeamId =
+      reportedUser?.team_id ?? reportedChatTeamId ?? null;
+    if (ownerTeamId) {
+      const { data: team } = await serviceClient
+        .from('teams')
+        .select('owner_id')
+        .eq('id', ownerTeamId)
+        .maybeSingle();
+      const ownerId = (team as { owner_id: string } | null)?.owner_id ?? null;
+      if (ownerId) {
+        await serviceClient.functions
+          .invoke('send-push', {
+            body: {
+              userId: ownerId,
+              title: 'Reports escalated',
+              body: 'A user, message, or chat in your team has been reported by 3+ people. Tap to review.',
+              data: { type: 'report_escalated', reportId: reportRow.id },
+            },
+          })
+          .catch((e: unknown) => {
+            console.error(
+              'report-handler push failed:',
+              e instanceof Error ? e.message : String(e),
+            );
+          });
+      }
+    }
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        escalated: true,
+        reporters: distinctReporters.size,
+      }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (err) {
+    console.error('report-handler unhandled error:', err);
+    const corsHeaders = getCorsHeaders(req);
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});

--- a/supabase/migrations/20260427160000_extend_reports_for_moderation.sql
+++ b/supabase/migrations/20260427160000_extend_reports_for_moderation.sql
@@ -1,0 +1,224 @@
+-- Extend reports table for the in-app moderation flow.
+--
+-- The reports table already exists from the initial schema with
+-- (reporter_id, reported_user_id, reported_message_id, reason, status).
+-- This migration ADDS what the moderation UI / Apple+Google App Review
+-- review require, without breaking existing RLS, triggers or tests:
+--
+--   * a discrete category enum (instead of free-form `reason`)
+--   * an optional free-text `description`
+--   * a `chat_id` so users can report an entire chat
+--   * `reviewed_at` timestamp
+--   * extra status values: `resolved`, `dismissed`
+--   * a generated `target_type` column so callers can filter on
+--     message/chat/user without inspecting which FK is set
+--
+-- The legacy `reason` column is kept (nullable) so older clients keep
+-- working until they ship the new enum.
+
+-- ------------------------------------------------------------------
+-- 1. Extend the report_status enum.
+-- ------------------------------------------------------------------
+-- Postgres requires ALTER TYPE ... ADD VALUE outside a transaction
+-- block; we use IF NOT EXISTS so the migration is idempotent.
+ALTER TYPE report_status ADD VALUE IF NOT EXISTS 'resolved';
+ALTER TYPE report_status ADD VALUE IF NOT EXISTS 'dismissed';
+
+-- ------------------------------------------------------------------
+-- 2. New report_category enum.
+-- ------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'report_category') THEN
+    CREATE TYPE report_category AS ENUM (
+      'inappropriate',
+      'harassment',
+      'spam',
+      'self_harm',
+      'illegal',
+      'other'
+    );
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------------
+-- 3. New columns on reports.
+-- ------------------------------------------------------------------
+ALTER TABLE reports
+  ADD COLUMN IF NOT EXISTS category report_category,
+  ADD COLUMN IF NOT EXISTS description text,
+  ADD COLUMN IF NOT EXISTS reported_chat_id uuid REFERENCES chats(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS reviewed_at timestamptz;
+
+-- Cap free-text length so a malicious client can't insert megabytes
+-- of text. 2000 chars is plenty for context.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'reports_description_length_chk'
+  ) THEN
+    ALTER TABLE reports
+      ADD CONSTRAINT reports_description_length_chk
+      CHECK (description IS NULL OR length(description) <= 2000);
+  END IF;
+END$$;
+
+-- Allow exactly one of (user, message, chat) to be the target. The
+-- legacy CHECK only required user OR message; widen to include chat.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'reports_reported_user_id_check'
+      AND conrelid = 'reports'::regclass
+  ) THEN
+    ALTER TABLE reports DROP CONSTRAINT reports_reported_user_id_check;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'reports_target_present_chk'
+  ) THEN
+    ALTER TABLE reports
+      ADD CONSTRAINT reports_target_present_chk CHECK (
+        (reported_user_id IS NOT NULL)::int
+        + (reported_message_id IS NOT NULL)::int
+        + (reported_chat_id IS NOT NULL)::int
+        >= 1
+      );
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------------
+-- 4. Generated target_type column for convenience filtering.
+-- ------------------------------------------------------------------
+-- Priority: message > chat > user (most specific first). This matches
+-- how the UI groups reports.
+ALTER TABLE reports
+  ADD COLUMN IF NOT EXISTS target_type text
+  GENERATED ALWAYS AS (
+    CASE
+      WHEN reported_message_id IS NOT NULL THEN 'message'
+      WHEN reported_chat_id    IS NOT NULL THEN 'chat'
+      WHEN reported_user_id    IS NOT NULL THEN 'user'
+      ELSE NULL
+    END
+  ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_reports_target_type ON reports(target_type);
+CREATE INDEX IF NOT EXISTS idx_reports_chat ON reports(reported_chat_id);
+CREATE INDEX IF NOT EXISTS idx_reports_status ON reports(status);
+CREATE INDEX IF NOT EXISTS idx_reports_created ON reports(created_at DESC);
+
+-- ------------------------------------------------------------------
+-- 5. Update the escalation trigger to count chat / message reports
+--    too, and to record reviewed_at.
+-- ------------------------------------------------------------------
+-- Threshold = 3 unique reporters per (target_type, target_id), only
+-- counting non-terminal statuses.
+CREATE OR REPLACE FUNCTION check_report_escalation()
+RETURNS TRIGGER AS $$
+DECLARE
+  report_count int := 0;
+BEGIN
+  IF NEW.reported_message_id IS NOT NULL THEN
+    SELECT COUNT(DISTINCT reporter_id) INTO report_count
+    FROM reports
+    WHERE reported_message_id = NEW.reported_message_id
+      AND status IN ('pending', 'reviewed');
+    IF report_count >= 3 THEN
+      UPDATE reports
+      SET status = 'escalated', escalated_at = now()
+      WHERE reported_message_id = NEW.reported_message_id
+        AND status IN ('pending', 'reviewed');
+    END IF;
+  ELSIF NEW.reported_chat_id IS NOT NULL THEN
+    SELECT COUNT(DISTINCT reporter_id) INTO report_count
+    FROM reports
+    WHERE reported_chat_id = NEW.reported_chat_id
+      AND status IN ('pending', 'reviewed');
+    IF report_count >= 3 THEN
+      UPDATE reports
+      SET status = 'escalated', escalated_at = now()
+      WHERE reported_chat_id = NEW.reported_chat_id
+        AND status IN ('pending', 'reviewed');
+    END IF;
+  ELSIF NEW.reported_user_id IS NOT NULL THEN
+    SELECT COUNT(DISTINCT reporter_id) INTO report_count
+    FROM reports
+    WHERE reported_user_id = NEW.reported_user_id
+      AND status IN ('pending', 'reviewed');
+    IF report_count >= 3 THEN
+      UPDATE reports
+      SET status = 'escalated', escalated_at = now()
+      WHERE reported_user_id = NEW.reported_user_id
+        AND status IN ('pending', 'reviewed');
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- ------------------------------------------------------------------
+-- 6. Touch reviewed_at when an Owner moves a report to reviewed/
+--    resolved/dismissed.
+-- ------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION set_report_reviewed_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.status IN ('reviewed', 'resolved', 'dismissed')
+     AND OLD.status IS DISTINCT FROM NEW.status
+     AND NEW.reviewed_at IS NULL THEN
+    NEW.reviewed_at := now();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+DROP TRIGGER IF EXISTS report_reviewed_at_trigger ON reports;
+CREATE TRIGGER report_reviewed_at_trigger BEFORE UPDATE ON reports
+  FOR EACH ROW EXECUTE FUNCTION set_report_reviewed_at();
+
+-- ------------------------------------------------------------------
+-- 7. Extend RLS so chat-target reports are visible to the right
+--    Owner — the reporter clause already handles "I see my own".
+-- ------------------------------------------------------------------
+DROP POLICY IF EXISTS reports_select ON reports;
+CREATE POLICY reports_select ON reports
+  FOR SELECT USING (
+    reporter_id = auth.uid()
+    OR is_team_owner_of(reporter_id)
+    OR (reported_user_id IS NOT NULL AND is_team_owner_of(reported_user_id))
+    OR (
+      reported_chat_id IS NOT NULL
+      AND auth_user_role() = 'owner'
+      AND chat_has_texter_from_team(reported_chat_id, auth_user_team_id())
+    )
+  );
+
+-- Owner update policy: allow setting status to reviewed/resolved/
+-- dismissed for reports the Owner is allowed to see, with reviewed_by
+-- pointing at themselves. Escalation stays trigger-driven.
+DROP POLICY IF EXISTS reports_update_owner ON reports;
+CREATE POLICY reports_update_owner ON reports
+  FOR UPDATE USING (
+    auth_user_role() = 'owner'
+    AND (
+      is_team_owner_of(reporter_id)
+      OR (reported_user_id IS NOT NULL AND is_team_owner_of(reported_user_id))
+      OR (
+        reported_chat_id IS NOT NULL
+        AND chat_has_texter_from_team(reported_chat_id, auth_user_team_id())
+      )
+    )
+  ) WITH CHECK (
+    reviewed_by = auth.uid()
+    AND status IN ('reviewed', 'resolved', 'dismissed')
+  );
+
+-- ------------------------------------------------------------------
+-- 8. Schema reload so PostgREST picks up the new columns.
+-- ------------------------------------------------------------------
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Builds the user-facing report flow + Owner moderation page that Apple/Google App Review require for UGC apps, on top of the existing `reports` table.

- DB migration extends `reports` additively: `category` enum (inappropriate / harassment / spam / self_harm / illegal / other), `description` (capped 2000 chars), `reported_chat_id`, `reviewed_at`, generated `target_type` column, and adds `resolved` / `dismissed` to the status enum. Escalation trigger now counts message- and chat-targeted reports too. RLS extended for chat-target visibility and a tighter `WITH CHECK` on Owner updates.
- New `report-handler` edge function fires fire-and-forget after each insert: re-checks the caller is the reporter, counts distinct reporters per target, and on >= 3 mails support@zemichat.com (HTML-escaped per audit fix #22) plus best-effort pushes the affected team's Owner.
- New `src/services/report.ts` exposes `reportMessage` / `reportChat` / `reportUser` / `getMyReports` / `getTeamReports` / `setReportStatus`.
- New `ReportButton` component drives a category-radio + description modal. Wired into `MessageContextMenu` (long-press, hidden for own messages) and `ChatInfo` (one entry for the chat, one for the other party in 1-on-1s).
- New Owner-only `TeamReports` page at `/team-reports`, filterable by status and category, with reviewed/resolved/dismissed actions and a mailto fallback to Zemi support. Linked from Dashboard quick actions.
- i18n keys added to all five locales.
- RLS test suite extended: category/description, chat-target, no-target rejection, description length cap, terminal-status transitions, `WITH CHECK` rollback prevention, and the 3-distinct-reporter escalation trigger.

PRD Â§15 (3-report escalation to Zemi support via mail) is honoured by the trigger + edge-function combo. Transparency model is preserved â€” Owner still sees everything via the existing reports_select policy.

Why additive vs the spec's `target_type/target_id`: the existing schema, RLS policies and tests all key off `reported_user_id`/`reported_message_id` and a working escalation trigger. Adding the new columns without ripping that out keeps every existing client / test path green and lets the legacy `reason` column carry a category label for older clients during rollout. Generated `target_type` gives the UI the same convenience the spec asked for.

## Test plan

- [ ] `supabase db reset` and confirm migration applies cleanly with the trigger + RLS in place.
- [ ] `npm test -- src/tests/rls/reports.rls.test.ts` (needs local Supabase + Docker).
- [x] `npx tsc --noEmit` passes locally.
- [ ] Manual: Texter long-presses someone else's message, picks Report, submits â€” appears in Owner's `/team-reports`.
- [ ] Manual: Owner moves a report through reviewed â†’ resolved â†’ dismissed and confirms `reviewed_at` is populated.
- [ ] Manual: trigger 3 distinct reporters against the same target and confirm support email lands + Owner push fires.
- [ ] Verify `RESEND_API_KEY` is set on the deployed `report-handler` env (same secret used by `send-invitation` / `send-support-email`).

## Open questions

- The Owner-side push uses the existing `send-push` function with a generic `report_escalated` payload. If we want a deeper deep-link than `/team-reports`, we should plumb the report id through the navigation handler.
- Older clients writing a free-form `reason` instead of a `category` will surface as "Other" in the Owner UI. Once 100% of clients are on the new schema we can drop the `reason` column.

Generated with Claude Code.
