### PR TITLE
fix: GitHub-issues #4, #5, #6, #7, #14, #15 (v1.5.12)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.zemichat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 29
-        versionName "1.5.11"
+        versionCode 30
+        versionName "1.5.12"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
             debugSymbolLevel 'FULL'

--- a/src/components/call/CallLogMessage.tsx
+++ b/src/components/call/CallLogMessage.tsx
@@ -1,6 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { IonButton, IonIcon } from '@ionic/react';
-import { call, videocam, callOutline, videocamOutline } from 'ionicons/icons';
+import {
+  call,
+  videocam,
+  callOutline,
+  videocamOutline,
+  warningOutline,
+} from 'ionicons/icons';
 import { type Message } from '../../types/database';
 
 interface CallLogMessageProps {
@@ -26,7 +32,11 @@ const CallLogMessage: React.FC<CallLogMessageProps> = ({
 
   const content = message.content || '';
   const isVideo = content.includes('video') || metadata?.call_type === 'video';
-  const isMissed = content.includes('missed') || metadata?.call_status === 'missed';
+  const isFailed = content.includes('failed') || metadata?.call_status === 'failed';
+  // Viktigt: kontrollera 'failed' före 'missed' eftersom innehållet vid
+  // failed-status inte innehåller "missed", men metadata-fältet är
+  // ömsesidigt uteslutande så ordningen spelar ingen roll i praktiken.
+  const isMissed = !isFailed && (content.includes('missed') || metadata?.call_status === 'missed');
   const isDeclined = content.includes('declined') || metadata?.call_status === 'declined';
   const isEnded = content.includes('ended') || metadata?.call_status === 'answered';
 
@@ -35,6 +45,9 @@ const CallLogMessage: React.FC<CallLogMessageProps> = ({
   const duration = durationMatch ? durationMatch[1] : null;
 
   const getIcon = () => {
+    if (isFailed) {
+      return warningOutline;
+    }
     if (isMissed || isDeclined) {
       return isVideo ? videocamOutline : callOutline;
     }
@@ -42,6 +55,9 @@ const CallLogMessage: React.FC<CallLogMessageProps> = ({
   };
 
   const getLabel = () => {
+    if (isFailed) {
+      return isVideo ? t('call.failedVideoCall') : t('call.failedVoiceCall');
+    }
     if (isMissed) {
       return isVideo ? t('call.missedVideoCall') : t('call.missedVoiceCall');
     }
@@ -57,6 +73,7 @@ const CallLogMessage: React.FC<CallLogMessageProps> = ({
   };
 
   const getStatusClass = () => {
+    if (isFailed) return 'failed';
     if (isMissed) return 'missed';
     if (isDeclined) return 'declined';
     return 'completed';
@@ -79,7 +96,7 @@ const CallLogMessage: React.FC<CallLogMessageProps> = ({
         {duration && <span className="call-duration">{duration}</span>}
       </div>
 
-      {(isMissed || isDeclined) && onCallBack && (
+      {(isMissed || isDeclined || isFailed) && onCallBack && (
         <IonButton
           className="callback-button"
           fill="clear"
@@ -119,6 +136,17 @@ const CallLogMessage: React.FC<CallLogMessageProps> = ({
         .call-log-message.missed .call-icon,
         .call-log-message.declined .call-icon {
           color: hsl(var(--destructive));
+        }
+
+        /* 'failed' = samtalet kom aldrig fram (token-fail, network etc.).
+           Använd warning-färg (orange) snarare än destructive (röd) — det är
+           inte mottagaren som missade, utan ett tekniskt fel. */
+        .call-log-message.failed .call-icon-container {
+          background: hsl(38 92% 50% / 0.12);
+        }
+
+        .call-log-message.failed .call-icon {
+          color: hsl(38 92% 50%);
         }
 
         .call-log-message.completed .call-icon-container {

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -29,9 +29,12 @@ interface MessageBubbleProps {
   onReact?: (message: MessageWithSender, rect: DOMRect) => void;
   onToggleReaction?: (messageId: string, emoji: string) => void;
   onContextMenu?: (message: MessageWithSender, rect: DOMRect) => void;
+  onJumpToMessage?: (messageId: string) => void;
   userId?: string;
   /** Current user's role — Owner sees original content of deleted-for-all messages */
   userRole?: string;
+  /** Highlight bubble briefly (e.g. when scrolled to via reply tap) */
+  isHighlighted?: boolean;
 }
 
 const MessageBubble: React.FC<MessageBubbleProps> = ({
@@ -49,8 +52,10 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
   onReact: _onReact,
   onToggleReaction,
   onContextMenu,
+  onJumpToMessage,
   userId: _userId,
   userRole,
+  isHighlighted = false,
 }) => {
   const { t } = useTranslation();
   const [swipeOffset, setSwipeOffset] = useState(0);
@@ -296,8 +301,9 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
 
       <div
         ref={bubbleRef}
-        className={`message-bubble ${isOwn ? 'own' : 'other'} ${isJustSent ? 'message-just-sent' : ''} ${message.type === 'sticker' ? 'sticker-only' : ''}`}
+        className={`message-bubble ${isOwn ? 'own' : 'other'} ${isJustSent ? 'message-just-sent' : ''} ${message.type === 'sticker' ? 'sticker-only' : ''} ${isHighlighted ? 'message-highlighted' : ''}`}
         data-testid={`message-bubble-${message.id}`}
+        data-message-id={message.id}
         onClick={handleTap}
         onTouchStart={handleTouchStart}
         onTouchMove={cancelLongPress}
@@ -326,7 +332,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
           <QuotedMessage
             message={message.reply_to}
             isOwn={isOwn}
-            onClick={() => {}}
+            onClick={() => onJumpToMessage?.(message.reply_to_id as string)}
           />
         )}
 
@@ -395,6 +401,15 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
           background: hsl(var(--bubble-received, var(--card)));
           color: hsl(var(--foreground));
           border-bottom-left-radius: 0.25rem;
+        }
+
+        .message-bubble.message-highlighted {
+          animation: highlight-flash 1.6s ease-out;
+        }
+
+        @keyframes highlight-flash {
+          0%   { box-shadow: 0 0 0 4px hsl(var(--primary) / 0.55); }
+          100% { box-shadow: 0 0 0 0 hsl(var(--primary) / 0); }
         }
 
         .sender-name {

--- a/src/contexts/CallContext.tsx
+++ b/src/contexts/CallContext.tsx
@@ -640,7 +640,7 @@ export function CallProvider({ children }: CallProviderProps) {
       .from('call_logs')
       .select('*')
       .eq('id', activeCall.callLogId)
-      .single();
+      .maybeSingle();
 
     if (data) {
       await createCallMessage(activeCall.chatId, data as unknown as CallLog);
@@ -768,7 +768,7 @@ export function CallProvider({ children }: CallProviderProps) {
         .from('call_logs')
         .select('type')
         .eq('id', signal.call_log_id)
-        .single() as { data: { type: string } | null };
+        .maybeSingle() as { data: { type: string } | null };
       if (log?.type === 'video') {
         detectedCallType = CallType.VIDEO;
       }

--- a/src/contexts/CallContext.tsx
+++ b/src/contexts/CallContext.tsx
@@ -40,7 +40,7 @@ import {
 } from '../services/agora';
 import {
   createCallLog,
-  deleteCallLog,
+  markCallFailed,
   updateCallStatus,
   endCallLog,
   sendCallSignal,
@@ -337,9 +337,15 @@ export function CallProvider({ children }: CallProviderProps) {
       // Get Agora token
       const { token, error: tokenError } = await getAgoraToken(chatId, callType);
       if (tokenError || !token) {
-        // Initieringen failade innan samtalet kunde nå mottagaren — ta bort
-        // den preliminära call_log:en så det inte loggas som "missat samtal".
-        await deleteCallLog(callLog.id);
+        // Initieringen failade innan samtalet kunde nå mottagaren — markera
+        // call_log:en som 'failed' (separat status från 'missed') och skapa
+        // en system-message i chatten så Owner och deltagare ser att försöket
+        // gjordes men aldrig kopplades.
+        await markCallFailed(callLog.id);
+        await createCallMessage(chatId, {
+          ...callLog,
+          status: CallStatus.FAILED,
+        } as CallLog);
         setCallError(mapCallError(tokenError, 'getAgoraToken'));
         setActiveCall((prev) => prev ? { ...prev, state: CallState.ENDED } : prev);
         setTimeout(() => cleanupCall(), 2500);
@@ -509,6 +515,19 @@ export function CallProvider({ children }: CallProviderProps) {
         incomingCall.callType
       );
       if (tokenError || !token) {
+        // Callee accepterade men token-fetch fail — samtalet bryts innan det
+        // kopplas. Det är inte 'missed' (callee svarade ju) utan 'failed'.
+        // Markera call_log + skapa system-message så båda sidor ser orsaken.
+        await markCallFailed(incomingCall.callLogId);
+        await deleteCallSignals(incomingCall.callLogId);
+        const { data: failedLog } = await supabase
+          .from('call_logs')
+          .select('*')
+          .eq('id', incomingCall.callLogId)
+          .maybeSingle();
+        if (failedLog) {
+          await createCallMessage(incomingCall.chatId, failedLog as unknown as CallLog);
+        }
         setCallError(mapCallError(tokenError, 'answerCall getAgoraToken'));
         await cleanupCall();
         return;

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -27,7 +27,7 @@ export function usePresence(userId: string | null | undefined): PresenceInfo {
         .from('users')
         .select('last_seen_at')
         .eq('id', userId)
-        .single();
+        .maybeSingle();
 
       if (data) {
         setLastSeenAt((data as { last_seen_at: string | null }).last_seen_at);

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -254,7 +254,8 @@
     "deactivateMessage": "Vil du deaktivere {{name}}? De vil ikke kunne logge ind.",
     "reactivateTitle": "Reaktiver Texter?",
     "reactivateMessage": "Vil du reaktivere {{name}}? De vil kunne logge ind igen.",
-    "canAccessWall": "Kan se væggen"
+    "canAccessWall": "Kan se væggen",
+    "pushEnabled": "Push-notifikationer til"
   },
   "oversight": {
     "title": "Texter-indsigt",
@@ -412,6 +413,7 @@
   },
   "settings": {
     "title": "Indstillinger",
+    "pushDisabledByTeam": "Push-notifikationer er slået fra af dit team. Beskeder vises i appen, men ingen notifikationer på låseskærmen.",
     "profile": "Profil",
     "exportData": "Download mine data",
     "exportDataDescription": "Eksporter alle dine data som JSON-fil",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -461,6 +461,8 @@
     "missedVideoCall": "Ubesvaret videoopkald",
     "declinedVoiceCall": "Afvist taleopkald",
     "declinedVideoCall": "Afvist videoopkald",
+    "failedVoiceCall": "Opkaldet kunne ikke forbindes",
+    "failedVideoCall": "Videoopkaldet kunne ikke forbindes",
     "voiceCallEnded": "Taleopkald ({{duration}})",
     "videoCallEnded": "Videoopkald ({{duration}})",
     "initiating": "Starter...",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -461,6 +461,8 @@
     "missedVideoCall": "Missed video call",
     "declinedVoiceCall": "Declined voice call",
     "declinedVideoCall": "Declined video call",
+    "failedVoiceCall": "Call could not be connected",
+    "failedVideoCall": "Video call could not be connected",
     "voiceCallEnded": "Voice call ({{duration}})",
     "videoCallEnded": "Video call ({{duration}})",
     "initiating": "Initiating...",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -254,7 +254,8 @@
     "deactivateMessage": "Do you want to deactivate {{name}}? They won't be able to log in.",
     "reactivateTitle": "Reactivate Texter?",
     "reactivateMessage": "Do you want to reactivate {{name}}? They will be able to log in again.",
-    "canAccessWall": "Can access the wall"
+    "canAccessWall": "Can access the wall",
+    "pushEnabled": "Push notifications on"
   },
   "oversight": {
     "title": "Texter oversight",
@@ -412,6 +413,7 @@
   },
   "settings": {
     "title": "Settings",
+    "pushDisabledByTeam": "Push notifications are disabled by your team. Messages still arrive in the app but no lock-screen alerts.",
     "profile": "Profile",
     "exportData": "Download my data",
     "exportDataDescription": "Export all your data as a JSON file",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -461,6 +461,8 @@
     "missedVideoCall": "Vastaamaton videopuhelu",
     "declinedVoiceCall": "Hylätty äänipuhelu",
     "declinedVideoCall": "Hylätty videopuhelu",
+    "failedVoiceCall": "Puhelua ei voitu yhdistää",
+    "failedVideoCall": "Videopuhelua ei voitu yhdistää",
     "voiceCallEnded": "Äänipuhelu ({{duration}})",
     "videoCallEnded": "Videopuhelu ({{duration}})",
     "initiating": "Aloitetaan...",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -254,7 +254,8 @@
     "deactivateMessage": "Haluatko poistaa käyttäjän {{name}} käytöstä? He eivät voi kirjautua sisään.",
     "reactivateTitle": "Ota Texter uudelleen käyttöön?",
     "reactivateMessage": "Haluatko ottaa käyttäjän {{name}} uudelleen käyttöön? He voivat kirjautua uudelleen.",
-    "canAccessWall": "Pääsy seinälle"
+    "canAccessWall": "Pääsy seinälle",
+    "pushEnabled": "Push-ilmoitukset päällä"
   },
   "oversight": {
     "title": "Texter-valvonta",
@@ -412,6 +413,7 @@
   },
   "settings": {
     "title": "Asetukset",
+    "pushDisabledByTeam": "Tiimisi on poistanut push-ilmoitukset käytöstä. Viestit saapuvat sovellukseen, mutta lukitusnäytölle ei tule ilmoituksia.",
     "profile": "Profiili",
     "exportData": "Lataa tietoni",
     "exportDataDescription": "Vie kaikki tietosi JSON-tiedostona",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -461,6 +461,8 @@
     "missedVideoCall": "Ubesvart videosamtale",
     "declinedVoiceCall": "Avvist talesamtale",
     "declinedVideoCall": "Avvist videosamtale",
+    "failedVoiceCall": "Samtalet kunne ikke kobles",
+    "failedVideoCall": "Videosamtalen kunne ikke kobles",
     "voiceCallEnded": "Talesamtale ({{duration}})",
     "videoCallEnded": "Videosamtale ({{duration}})",
     "initiating": "Starter...",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -254,7 +254,8 @@
     "deactivateMessage": "Vil du deaktivere {{name}}? De vil ikke kunne logge inn.",
     "reactivateTitle": "Reaktiver Texter?",
     "reactivateMessage": "Vil du reaktivere {{name}}? De vil kunne logge inn igjen.",
-    "canAccessWall": "Kan se veggen"
+    "canAccessWall": "Kan se veggen",
+    "pushEnabled": "Push-varsler på"
   },
   "oversight": {
     "title": "Texter-innsyn",
@@ -412,6 +413,7 @@
   },
   "settings": {
     "title": "Innstillinger",
+    "pushDisabledByTeam": "Push-varsler er slått av av teamet ditt. Meldinger vises i appen, men ingen varsler på låseskjermen.",
     "profile": "Profil",
     "exportData": "Last ned mine data",
     "exportDataDescription": "Eksporter alle dine data som JSON-fil",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -461,6 +461,8 @@
     "missedVideoCall": "Missat videosamtal",
     "declinedVoiceCall": "Avvisat röstsamtal",
     "declinedVideoCall": "Avvisat videosamtal",
+    "failedVoiceCall": "Samtal kunde inte kopplas",
+    "failedVideoCall": "Videosamtal kunde inte kopplas",
     "voiceCallEnded": "Röstsamtal ({{duration}})",
     "videoCallEnded": "Videosamtal ({{duration}})",
     "initiating": "Initierar...",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -254,7 +254,8 @@
     "deactivateMessage": "Vill du inaktivera {{name}}? De kommer inte kunna logga in.",
     "reactivateTitle": "Återaktivera Texter?",
     "reactivateMessage": "Vill du återaktivera {{name}}? De kommer kunna logga in igen.",
-    "canAccessWall": "Kan se väggen"
+    "canAccessWall": "Kan se väggen",
+    "pushEnabled": "Push-notiser på"
   },
   "oversight": {
     "title": "Texter-insyn",
@@ -412,6 +413,7 @@
   },
   "settings": {
     "title": "Inställningar",
+    "pushDisabledByTeam": "Push-notiser är avstängda av ditt team. Meddelanden visas i appen men du får inga aviseringar på låsskärmen.",
     "profile": "Profil",
     "exportData": "Ladda ner min data",
     "exportDataDescription": "Exportera all din data som JSON-fil",

--- a/src/pages/ChatView.tsx
+++ b/src/pages/ChatView.tsx
@@ -104,6 +104,7 @@ const ChatView: React.FC = () => {
 
   // Reply state
   const [replyTo, setReplyTo] = useState<MessageWithSender | null>(null);
+  const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
 
   // Reactions state
   const [reactions, setReactions] = useState<Map<string, GroupedReaction[]>>(new Map());
@@ -513,6 +514,18 @@ const ChatView: React.FC = () => {
     inputRef.current?.focus();
   };
 
+  const handleJumpToMessage = useCallback((messageId: string) => {
+    const el = document.querySelector(
+      `[data-message-id="${messageId}"]`
+    ) as HTMLElement | null;
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setHighlightedMessageId(messageId);
+    setTimeout(() => {
+      setHighlightedMessageId((prev) => (prev === messageId ? null : prev));
+    }, 1700);
+  }, []);
+
   const handleContextMenu = (message: MessageWithSender, _rect: DOMRect) => {
     setContextMenuTarget(message);
   };
@@ -839,9 +852,11 @@ const ChatView: React.FC = () => {
                       galleryUrls={galleryUrls}
                       onReply={() => handleReply(message)}
                       onContextMenu={(msg, rect) => handleContextMenu(msg, rect)}
+                      onJumpToMessage={handleJumpToMessage}
                       userId={profile?.id}
                       userRole={profile?.role}
                       onToggleReaction={handleToggleReaction}
+                      isHighlighted={highlightedMessageId === message.id}
                     />
                   </div>
                 </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -33,6 +33,7 @@ import {
   copyOutline,
   peopleOutline,
   newspaperOutline,
+  notificationsOffOutline,
 } from 'ionicons/icons';
 import { Capacitor } from '@capacitor/core';
 import { App as CapacitorApp } from '@capacitor/app';
@@ -81,6 +82,7 @@ const Settings: React.FC = () => {
   const isTexter = profile?.role === UserRole.TEXTER;
 
   const [memberCount, setMemberCount] = useState(0);
+  const [pushDisabledByTeam, setPushDisabledByTeam] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [exportSuccess, setExportSuccess] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
@@ -210,6 +212,24 @@ const Settings: React.FC = () => {
       setWallEnabled(profile.wall_enabled);
     }
   }, [profile?.wall_enabled]);
+
+  useEffect(() => {
+    if (!isTexter || !profile?.id) return;
+    let cancelled = false;
+    (async () => {
+      const { data } = await supabase
+        .from('texter_settings')
+        .select('push_enabled')
+        .eq('user_id', profile.id)
+        .maybeSingle<{ push_enabled: boolean }>();
+      if (!cancelled) {
+        setPushDisabledByTeam(data?.push_enabled === false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isTexter, profile?.id]);
 
   const handleWallToggle = async (checked: boolean) => {
     if (!profile) return;
@@ -465,6 +485,16 @@ const Settings: React.FC = () => {
           {isTexter && (
             <div className="section">
               <SOSButton />
+            </div>
+          )}
+
+          {/* Push disabled by Owner/Super — info banner */}
+          {isTexter && pushDisabledByTeam && (
+            <div className="section">
+              <div className="push-disabled-banner" data-testid="push-disabled-banner">
+                <IonIcon icon={notificationsOffOutline} />
+                <span>{t('settings.pushDisabledByTeam')}</span>
+              </div>
             </div>
           )}
 
@@ -810,6 +840,22 @@ const Settings: React.FC = () => {
 
           .section {
             margin-bottom: 2rem;
+          }
+
+          .push-disabled-banner {
+            display: flex;
+            align-items: center;
+            gap: 0.625rem;
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            background: hsl(var(--muted) / 0.4);
+            color: hsl(var(--muted-foreground));
+            font-size: 0.875rem;
+          }
+
+          .push-disabled-banner ion-icon {
+            font-size: 1.25rem;
+            flex-shrink: 0;
           }
 
           .section-title {

--- a/src/pages/TexterDetail.tsx
+++ b/src/pages/TexterDetail.tsx
@@ -63,7 +63,7 @@ const TexterDetail: React.FC = () => {
       .from('users')
       .select('*')
       .eq('id', userId)
-      .single();
+      .maybeSingle();
 
     if (userError || !userData) {
       history.replace('/chats');

--- a/src/pages/TexterDetail.tsx
+++ b/src/pages/TexterDetail.tsx
@@ -33,6 +33,7 @@ import {
   banOutline,
   checkmarkCircleOutline,
   newspaperOutline,
+  notificationsOutline,
 } from 'ionicons/icons';
 import { supabase } from '../services/supabase';
 import {
@@ -227,6 +228,12 @@ const TexterDetail: React.FC = () => {
           label: t('texterDetail.canAccessWall'),
           icon: newspaperOutline,
           value: settings.can_access_wall,
+        },
+        {
+          field: 'push_enabled' as const,
+          label: t('texterDetail.pushEnabled'),
+          icon: notificationsOutline,
+          value: settings.push_enabled,
         },
       ]
     : [];

--- a/src/services/call.ts
+++ b/src/services/call.ts
@@ -66,16 +66,20 @@ export async function createCallLog(
 }
 
 /**
- * Delete a call log. Används när initieringen failade och vi inte vill
- * att ett vilseledande "missat samtal" ska finnas kvar hos mottagaren.
+ * Mark a call log as 'failed' — used när samtalet aldrig kom fram till
+ * mottagaren (token-fail, network-fail, agora-init-fail). Skiljer sig från
+ * 'missed' (där callee faktiskt nåddes men inte svarade i tid).
  */
-export async function deleteCallLog(
+export async function markCallFailed(
   callLogId: string
 ): Promise<{ error: Error | null }> {
   try {
     const { error } = await supabase
       .from('call_logs')
-      .delete()
+      .update({
+        status: CallStatus.FAILED,
+        ended_at: new Date().toISOString(),
+      } as never)
       .eq('id', callLogId);
 
     if (error) {
@@ -325,6 +329,9 @@ export async function createCallMessage(
         break;
       case CallStatus.DECLINED:
         content = `${callTypeLabel}_call_declined`;
+        break;
+      case CallStatus.FAILED:
+        content = `${callTypeLabel}_call_failed`;
         break;
       default:
         content = `${callTypeLabel}_call`;

--- a/src/services/call.ts
+++ b/src/services/call.ts
@@ -278,7 +278,7 @@ export function subscribeToCallSignals(
           .from('users')
           .select('*')
           .eq('id', signal.caller_id)
-          .single();
+          .maybeSingle();
 
         if (caller) {
           onSignal(signal, caller as User);
@@ -368,7 +368,7 @@ export async function canMakeCall(
       .from('users')
       .select('role')
       .eq('id', userId)
-      .single();
+      .maybeSingle();
 
     if (userError || !userData) {
       return { canCall: false, error: new Error('User not found') };
@@ -421,7 +421,7 @@ export async function canScreenShare(
       .from('users')
       .select('role')
       .eq('id', userId)
-      .single();
+      .maybeSingle();
 
     if (userError || !userData) {
       return { canShare: false, error: new Error('User not found') };

--- a/src/services/location.ts
+++ b/src/services/location.ts
@@ -71,7 +71,7 @@ export async function canShareLocation(chatId: string): Promise<boolean> {
     .from('users')
     .select('role, team_id')
     .eq('id', user.id)
-    .single();
+    .maybeSingle();
 
   if (!profile) return false;
 
@@ -86,7 +86,7 @@ export async function canShareLocation(chatId: string): Promise<boolean> {
     .select('id')
     .eq('team_id', typedProfile.team_id)
     .eq('role', UserRole.OWNER)
-    .single();
+    .maybeSingle();
 
   if (!teamOwner) return false;
 

--- a/src/services/members.ts
+++ b/src/services/members.ts
@@ -59,7 +59,7 @@ export async function getTeamMembers(): Promise<{ members: User[]; error: Error 
     .from('users')
     .select('team_id')
     .eq('id', authUser.id)
-    .single();
+    .maybeSingle();
 
   if (!profile) {
     return { members: [], error: new Error('Profile not found') };

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -165,7 +165,7 @@ export function subscribeToMessages(
             sender:users!messages_sender_id_fkey (*)
           `)
           .eq('id', payload.new.id)
-          .single();
+          .maybeSingle();
 
         if (data) {
           onMessage(data as unknown as MessageWithSender);
@@ -189,7 +189,7 @@ export function subscribeToMessages(
             sender:users!messages_sender_id_fkey (*)
           `)
           .eq('id', payload.new.id)
-          .single();
+          .maybeSingle();
 
         if (data) {
           onUpdate(data as unknown as MessageWithSender);

--- a/src/services/sos.ts
+++ b/src/services/sos.ts
@@ -123,7 +123,7 @@ export async function getUnacknowledgedAlerts(): Promise<{
       .from('users')
       .select('team_id, role')
       .eq('id', user.id)
-      .single();
+      .maybeSingle();
 
     if (userError || !currentUser) {
       return { alerts: [], error: new Error('Could not get user info') };
@@ -208,7 +208,7 @@ export async function getAllAlerts(limit = 50): Promise<{
       .from('users')
       .select('team_id, role')
       .eq('id', user.id)
-      .single();
+      .maybeSingle();
 
     if (userError || !currentUser) {
       return { alerts: [], error: new Error('Could not get user info') };

--- a/src/services/subscription.ts
+++ b/src/services/subscription.ts
@@ -311,7 +311,7 @@ async function getSubscriptionStatusFromDatabase(): Promise<{
       .from('users')
       .select('team_id')
       .eq('id', user.id)
-      .single();
+      .maybeSingle();
 
     if (userError || !userData) {
       return { status: null, error: new Error('User not found') };
@@ -322,7 +322,7 @@ async function getSubscriptionStatusFromDatabase(): Promise<{
       .from('teams')
       .select('plan, trial_ends_at')
       .eq('id', (userData as { team_id: string }).team_id)
-      .single();
+      .maybeSingle();
 
     if (teamError || !teamData) {
       return { status: null, error: new Error('Team not found') };
@@ -374,7 +374,7 @@ export async function getSubscriptionStatusForUser(userId: string): Promise<{
       .from('users')
       .select('team_id')
       .eq('id', userId)
-      .single();
+      .maybeSingle();
 
     if (userError || !userData) {
       return { status: null, error: new Error('User not found') };
@@ -385,7 +385,7 @@ export async function getSubscriptionStatusForUser(userId: string): Promise<{
       .from('teams')
       .select('plan, trial_ends_at')
       .eq('id', (userData as { team_id: string }).team_id)
-      .single();
+      .maybeSingle();
 
     if (teamError || !teamData) {
       return { status: null, error: new Error('Team not found') };

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -48,10 +48,14 @@ export async function createTeam({
  * Get the current user's team.
  */
 export async function getMyTeam(): Promise<{ team: Team | null; error: Error | null }> {
-  const { data, error } = await supabase.from('teams').select('*').single();
+  const { data, error } = await supabase.from('teams').select('*').maybeSingle();
 
   if (error) {
     return { team: null, error: new Error(error.message) };
+  }
+
+  if (!data) {
+    return { team: null, error: new Error('No team found') };
   }
 
   return { team: data as unknown as Team, error: null };
@@ -69,10 +73,18 @@ export async function getMyProfile(): Promise<{ user: User | null; error: Error 
     return { user: null, error: new Error('Not authenticated') };
   }
 
-  const { data, error } = await supabase.from('users').select('*').eq('id', authUser.id).single();
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .eq('id', authUser.id)
+    .maybeSingle();
 
   if (error) {
     return { user: null, error: new Error(error.message) };
+  }
+
+  if (!data) {
+    return { user: null, error: new Error('User profile not found') };
   }
 
   return { user: data as unknown as User, error: null };

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -105,7 +105,8 @@
 }
 
 * {
-  font-family: 'Nunito', 'Outfit', system-ui, -apple-system, sans-serif;
+  font-family: 'Nunito', 'Outfit', system-ui, -apple-system, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji';
 }
 
 /* Typography hierarchy */

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -70,6 +70,7 @@ export enum CallStatus {
   MISSED = 'missed',
   ANSWERED = 'answered',
   DECLINED = 'declined',
+  FAILED = 'failed',
 }
 
 export enum PlatformType {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -132,6 +132,7 @@ export interface TexterSettings {
   can_video_call: boolean;
   can_screen_share: boolean;
   can_access_wall: boolean;
+  push_enabled: boolean;
   quiet_hours_start: string | null;
   quiet_hours_end: string | null;
   quiet_hours_days: number[] | null;

--- a/supabase/functions/agora-token/index.ts
+++ b/supabase/functions/agora-token/index.ts
@@ -72,7 +72,7 @@ serve(async (req) => {
       .eq('chat_id', chatId)
       .eq('user_id', user.id)
       .is('left_at', null)
-      .single();
+      .maybeSingle();
 
     if (membershipError || !membership) {
       return new Response(
@@ -85,7 +85,7 @@ serve(async (req) => {
       .from('users')
       .select('role')
       .eq('id', user.id)
-      .single();
+      .maybeSingle();
 
     if (profileError || !userProfile) {
       return new Response(

--- a/supabase/functions/call-push/index.ts
+++ b/supabase/functions/call-push/index.ts
@@ -299,7 +299,7 @@ serve(async (req) => {
     // Filter to active users only
     const { data: activeUsers } = await supabase
       .from('users')
-      .select('id')
+      .select('id, role')
       .in('id', recipientIds)
       .eq('is_active', true);
 
@@ -310,7 +310,34 @@ serve(async (req) => {
       });
     }
 
-    const activeIds = activeUsers.map((u) => u.id);
+    // Honour Owner/Super push_enabled toggle on Texters
+    const texterIds = activeUsers
+      .filter((u) => u.role === 'texter')
+      .map((u) => u.id);
+
+    let pushDisabledIds: Set<string> = new Set();
+    if (texterIds.length > 0) {
+      const { data: ts } = await supabase
+        .from('texter_settings')
+        .select('user_id, push_enabled')
+        .in('user_id', texterIds);
+      if (ts) {
+        for (const row of ts) {
+          if (row.push_enabled === false) pushDisabledIds.add(row.user_id);
+        }
+      }
+    }
+
+    const activeIds = activeUsers
+      .map((u) => u.id)
+      .filter((id) => !pushDisabledIds.has(id));
+
+    if (activeIds.length === 0) {
+      return new Response(JSON.stringify({ sent: 0 }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
 
     // Get push tokens for recipients (include token_type for routing)
     const { data: tokens } = await supabase

--- a/supabase/functions/call-push/index.ts
+++ b/supabase/functions/call-push/index.ts
@@ -334,7 +334,7 @@ serve(async (req) => {
         .from('users')
         .select('display_name, avatar_url')
         .eq('id', user.id)
-        .single();
+        .maybeSingle();
 
       callData = {
         type: 'incoming_call',

--- a/supabase/functions/create-invited-user/index.ts
+++ b/supabase/functions/create-invited-user/index.ts
@@ -56,7 +56,7 @@ serve(async (req) => {
       .from('team_invitations')
       .select('*')
       .eq('token', token)
-      .single();
+      .maybeSingle();
 
     if (invError || !invitation) {
       return new Response(

--- a/supabase/functions/friend-push/index.ts
+++ b/supabase/functions/friend-push/index.ts
@@ -1,0 +1,411 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+// ============================================================
+// Issue #7 — Push notifications for friend requests
+// ============================================================
+//
+// Triggered by DB trigger `notify_friend_request` (see migration
+// 20260501110000_friend_push_triggers.sql) when:
+//   - A new pending friendship row is inserted (event='request')
+//   - A friendship transitions from pending → accepted (event='accepted')
+//
+// Auth: Bearer shared secret in Authorization header. Same secret as
+// send-push (vault key `pg_net_shared_secret`, edge env PG_NET_SHARED_SECRET).
+//
+// FCM/APNs delivery mirrors send-push but is stripped down — no chat,
+// no quiet hours, no rate limiting (DB triggers fire at most a handful of
+// times per friendship lifetime, so volume is bounded by user activity).
+
+interface RequestPayload {
+  recipient_id: string;
+  sender_id: string;
+  event: 'request' | 'accepted';
+}
+
+interface PushTokenRow {
+  id: string;
+  user_id: string;
+  token: string;
+  platform: string;
+}
+
+interface FcmMessage {
+  message: {
+    token: string;
+    notification: {
+      title: string;
+      body: string;
+    };
+    data: Record<string, string>;
+    android?: {
+      priority: string;
+    };
+    apns?: {
+      headers: Record<string, string>;
+      payload: {
+        aps: {
+          sound?: string;
+          badge?: number;
+        };
+      };
+    };
+  };
+}
+
+// ============================================================
+// FCM Authentication (Google OAuth2 via Service Account)
+// — duplicated from send-push to keep edge functions self-contained
+// ============================================================
+
+function base64url(data: Uint8Array): string {
+  let binary = '';
+  for (const byte of data) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const pemBody = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, '')
+    .replace(/-----END PRIVATE KEY-----/, '')
+    .replace(/\s/g, '');
+  const binaryDer = Uint8Array.from(atob(pemBody), (c) => c.charCodeAt(0));
+
+  return crypto.subtle.importKey(
+    'pkcs8',
+    binaryDer,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+}
+
+async function createSignedJwt(
+  clientEmail: string,
+  privateKey: string
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = {
+    iss: clientEmail,
+    sub: clientEmail,
+    aud: 'https://oauth2.googleapis.com/token',
+    iat: now,
+    exp: now + 3600,
+    scope: 'https://www.googleapis.com/auth/firebase.messaging',
+  };
+
+  const encoder = new TextEncoder();
+  const headerB64 = base64url(encoder.encode(JSON.stringify(header)));
+  const payloadB64 = base64url(encoder.encode(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const key = await importPrivateKey(privateKey);
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    encoder.encode(signingInput)
+  );
+
+  const signatureB64 = base64url(new Uint8Array(signature));
+  return `${signingInput}.${signatureB64}`;
+}
+
+async function getAccessToken(
+  clientEmail: string,
+  privateKey: string
+): Promise<string> {
+  const jwt = await createSignedJwt(clientEmail, privateKey);
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${jwt}`,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OAuth2 token exchange failed: ${response.status} ${text}`);
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/**
+ * Constant-time string compare. Avoids timing oracles on the shared secret.
+ */
+function safeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+function buildNotification(
+  event: 'request' | 'accepted',
+  senderName: string
+): { title: string; body: string } {
+  if (event === 'request') {
+    return {
+      title: 'Vänförfrågan',
+      body: `${senderName} vill bli vän med dig`,
+    };
+  }
+  return {
+    title: 'Vänförfrågan accepterad',
+    body: `${senderName} accepterade din vänförfrågan`,
+  };
+}
+
+// ============================================================
+// Main Handler
+// ============================================================
+
+serve(async (req) => {
+  // No CORS — invoked internally by pg_net
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  try {
+    // Authenticate caller against the shared secret. Same pattern as send-push.
+    const expectedSecret = Deno.env.get('PG_NET_SHARED_SECRET') ?? '';
+    if (!expectedSecret) {
+      console.error('PG_NET_SHARED_SECRET not configured');
+      return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const authHeader = req.headers.get('Authorization') ?? '';
+    const presented = authHeader.startsWith('Bearer ')
+      ? authHeader.slice('Bearer '.length)
+      : '';
+    if (!presented || !safeCompare(presented, expectedSecret)) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Parse payload
+    const payload: RequestPayload = await req.json();
+    const { recipient_id, sender_id, event } = payload;
+
+    if (!recipient_id || !sender_id || !event) {
+      return new Response(JSON.stringify({ error: 'Missing required fields' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (event !== 'request' && event !== 'accepted') {
+      return new Response(JSON.stringify({ error: 'Invalid event' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Service-role client (bypasses RLS)
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Verify recipient is active and look up their role for the texter check
+    const { data: recipient, error: recipientErr } = await supabase
+      .from('users')
+      .select('id, role, is_active')
+      .eq('id', recipient_id)
+      .maybeSingle();
+
+    if (recipientErr || !recipient) {
+      return new Response(JSON.stringify({ error: 'Recipient not found' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (!recipient.is_active) {
+      return new Response(JSON.stringify({ sent: 0, reason: 'inactive' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // For Texters, honour the push_enabled toggle in texter_settings.
+    if (recipient.role === 'texter') {
+      const { data: settings } = await supabase
+        .from('texter_settings')
+        .select('push_enabled')
+        .eq('user_id', recipient_id)
+        .maybeSingle();
+
+      if (settings?.push_enabled === false) {
+        return new Response(
+          JSON.stringify({ sent: 0, reason: 'push_disabled' }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+    }
+
+    // Sender display name
+    const { data: sender } = await supabase
+      .from('users')
+      .select('display_name')
+      .eq('id', sender_id)
+      .maybeSingle();
+
+    const senderName = sender?.display_name || 'Någon';
+
+    // Push tokens for recipient
+    const { data: tokens } = await supabase
+      .from('push_tokens')
+      .select('id, user_id, token, platform')
+      .eq('user_id', recipient_id);
+
+    if (!tokens || tokens.length === 0) {
+      return new Response(JSON.stringify({ sent: 0 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // FCM credentials
+    const fcmServiceAccountJson = Deno.env.get('FCM_SERVICE_ACCOUNT_JSON');
+    if (!fcmServiceAccountJson) {
+      console.error('FCM_SERVICE_ACCOUNT_JSON not configured');
+      return new Response(JSON.stringify({ error: 'FCM not configured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const serviceAccount = JSON.parse(fcmServiceAccountJson);
+    const projectId = serviceAccount.project_id;
+
+    const accessToken = await getAccessToken(
+      serviceAccount.client_email,
+      serviceAccount.private_key
+    );
+
+    const { title, body } = buildNotification(event, senderName);
+    const fcmUrl = `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;
+
+    let sentCount = 0;
+    const invalidTokenIds: string[] = [];
+
+    const sendPromises = tokens.map(async (tokenRow: PushTokenRow) => {
+      const fcmMessage: FcmMessage = {
+        message: {
+          token: tokenRow.token,
+          notification: {
+            title,
+            body,
+          },
+          data: {
+            type: event === 'request' ? 'friend_request' : 'friend_accepted',
+            senderId: sender_id,
+            recipientId: recipient_id,
+          },
+          android: {
+            priority: 'high',
+          },
+          ...(tokenRow.platform === 'ios'
+            ? {
+                apns: {
+                  headers: {
+                    'apns-priority': '10',
+                  },
+                  payload: {
+                    aps: {
+                      sound: 'default',
+                      badge: 1,
+                    },
+                  },
+                },
+              }
+            : {}),
+        },
+      };
+
+      try {
+        const response = await fetch(fcmUrl, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(fcmMessage),
+        });
+
+        if (response.ok) {
+          sentCount++;
+        } else {
+          const errorData = await response.json();
+          const errorCode = errorData?.error?.details?.[0]?.errorCode;
+
+          if (
+            response.status === 404 ||
+            errorCode === 'UNREGISTERED' ||
+            errorCode === 'INVALID_ARGUMENT'
+          ) {
+            invalidTokenIds.push(tokenRow.id);
+          } else {
+            console.error(
+              `FCM send failed for token ${tokenRow.id}:`,
+              response.status,
+              JSON.stringify(errorData)
+            );
+          }
+        }
+      } catch (err) {
+        console.error(`FCM send error for token ${tokenRow.id}:`, err);
+      }
+    });
+
+    await Promise.all(sendPromises);
+
+    if (invalidTokenIds.length > 0) {
+      const { error: deleteError } = await supabase
+        .from('push_tokens')
+        .delete()
+        .in('id', invalidTokenIds);
+
+      if (deleteError) {
+        console.error('Failed to delete invalid tokens:', deleteError.message);
+      } else {
+        console.log(`Cleaned up ${invalidTokenIds.length} invalid push tokens`);
+      }
+    }
+
+    return new Response(
+      JSON.stringify({ sent: sentCount, cleaned: invalidTokenIds.length }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (error) {
+    console.error('friend-push error:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/send-invitation/index.ts
+++ b/supabase/functions/send-invitation/index.ts
@@ -117,7 +117,7 @@ serve(async (req) => {
       .from('team_invitations')
       .select('*, teams(name), users!team_invitations_invited_by_fkey(display_name)')
       .eq('id', invitationId)
-      .single();
+      .maybeSingle();
 
     if (invError || !invitation) {
       return new Response(JSON.stringify({ error: 'Invitation not found' }), {

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -376,15 +376,22 @@ serve(async (req) => {
       .map((u) => u.id);
 
     let quietHoursBlockedIds: Set<string> = new Set();
+    let pushDisabledIds: Set<string> = new Set();
 
     if (texterIds.length > 0) {
       const { data: texterSettings } = await supabase
         .from('texter_settings')
-        .select('user_id, quiet_hours_start, quiet_hours_end, quiet_hours_days')
+        .select(
+          'user_id, quiet_hours_start, quiet_hours_end, quiet_hours_days, push_enabled'
+        )
         .in('user_id', texterIds);
 
       if (texterSettings) {
         for (const settings of texterSettings) {
+          if (settings.push_enabled === false) {
+            pushDisabledIds.add(settings.user_id);
+            continue;
+          }
           if (isInQuietHours(settings)) {
             quietHoursBlockedIds.add(settings.user_id);
           }
@@ -395,7 +402,9 @@ serve(async (req) => {
     // Final eligible user IDs
     const eligibleUserIds = activeUsers
       .map((u) => u.id)
-      .filter((id) => !quietHoursBlockedIds.has(id));
+      .filter(
+        (id) => !quietHoursBlockedIds.has(id) && !pushDisabledIds.has(id)
+      );
 
     if (eligibleUserIds.length === 0) {
       return new Response(JSON.stringify({ sent: 0 }), {

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -302,7 +302,7 @@ serve(async (req) => {
       .select('id, sender_id')
       .eq('id', message_id)
       .gte('created_at', fiveMinutesAgo)
-      .single();
+      .maybeSingle();
 
     if (msgError || !message) {
       return new Response(JSON.stringify({ error: 'Invalid or expired message' }), {
@@ -317,12 +317,12 @@ serve(async (req) => {
         .from('users')
         .select('display_name')
         .eq('id', sender_id)
-        .single(),
+        .maybeSingle(),
       supabase
         .from('chats')
         .select('name, is_group')
         .eq('id', chat_id)
-        .single(),
+        .maybeSingle(),
     ]);
 
     const senderName = sender?.display_name || 'Någon';

--- a/supabase/migrations/20260501100000_texter_push_enabled.sql
+++ b/supabase/migrations/20260501100000_texter_push_enabled.sql
@@ -1,0 +1,9 @@
+-- Add push_enabled toggle to texter_settings
+-- Owner/Super can disable push notifications for individual Texters.
+-- Default true so existing Texters keep current behaviour.
+
+ALTER TABLE public.texter_settings
+  ADD COLUMN IF NOT EXISTS push_enabled BOOLEAN NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN public.texter_settings.push_enabled IS
+  'When false, send-push edge function skips FCM/APNs delivery for this Texter. In-app messages still arrive.';

--- a/supabase/migrations/20260501110000_friend_push_triggers.sql
+++ b/supabase/migrations/20260501110000_friend_push_triggers.sql
@@ -1,0 +1,129 @@
+-- Issue #7: Push notifications for friend requests.
+--
+-- When someone sends a friend request, the addressee should get a push
+-- notification. When the addressee accepts, the original requester should
+-- get a push notification.
+--
+-- Implementation mirrors notify_new_message (see migration
+-- 20260427110000_send_push_shared_secret.sql): SECURITY DEFINER plpgsql
+-- function reads the shared secret from Vault, posts to the friend-push
+-- edge function via net.http_post with a Bearer header. URL is hardcoded
+-- to production with a fallback to a local-dev custom GUC.
+--
+-- DEPLOYMENT — uses the SAME secret as send-push:
+--   - PG_NET_SHARED_SECRET edge env (already configured for send-push)
+--   - vault.secrets row name='pg_net_shared_secret' (already configured)
+-- No additional secret setup required if send-push is already deployed.
+--
+-- Auto-team friendships (see 20260210120000_auto_team_friendships.sql) insert
+-- with status='accepted' directly. The INSERT trigger only fires on
+-- status='pending', so those skip the 'request' event. The UPDATE trigger
+-- additionally checks OLD.status='pending' so it only fires on real
+-- pending→accepted transitions, not on accepted→accepted no-ops or any
+-- future status change starting from accepted.
+
+-- ============================================================
+-- 1. Trigger function
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION notify_friend_request()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, net, vault
+AS $$
+DECLARE
+  edge_function_url text;
+  shared_secret text;
+  payload jsonb;
+  request_headers jsonb;
+  v_recipient_id uuid;
+  v_sender_id uuid;
+  v_event text;
+BEGIN
+  -- Decide event + direction based on TG_OP and status transition.
+  IF TG_OP = 'INSERT' THEN
+    -- Only pending inserts produce a 'request' event. Auto-accepted
+    -- team friendships insert directly with status='accepted' and must
+    -- be ignored here.
+    IF NEW.status <> 'pending' THEN
+      RETURN NEW;
+    END IF;
+
+    v_event := 'request';
+    v_recipient_id := NEW.addressee_id;
+    v_sender_id := NEW.requester_id;
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- Only real pending → accepted transitions count. This guards against
+    -- accepted-on-insert auto friendships ever surfacing as an 'accepted'
+    -- event if some future migration UPDATEs them, and against any other
+    -- status flip that happens to land on 'accepted'.
+    IF OLD.status = 'pending' AND NEW.status = 'accepted' THEN
+      v_event := 'accepted';
+      -- Notify the original requester that their request went through.
+      v_recipient_id := NEW.requester_id;
+      v_sender_id := NEW.addressee_id;
+    ELSE
+      RETURN NEW;
+    END IF;
+
+  ELSE
+    RETURN NEW;
+  END IF;
+
+  -- Edge function URL: prod by default, GUC override for local dev.
+  edge_function_url := COALESCE(
+    current_setting('app.settings.edge_function_url', true) || '/friend-push',
+    'https://qrrorlxocpxvqcfdipbq.supabase.co/functions/v1/friend-push'
+  );
+
+  -- Pull shared secret from Vault. Same secret as send-push.
+  SELECT decrypted_secret INTO shared_secret
+  FROM vault.decrypted_secrets
+  WHERE name = 'pg_net_shared_secret'
+  LIMIT 1;
+
+  IF shared_secret IS NULL OR shared_secret = '' THEN
+    RAISE WARNING 'notify_friend_request: vault secret pg_net_shared_secret not set, skipping push';
+    RETURN NEW;
+  END IF;
+
+  payload := jsonb_build_object(
+    'recipient_id', v_recipient_id,
+    'sender_id', v_sender_id,
+    'event', v_event
+  );
+
+  request_headers := jsonb_build_object(
+    'Content-Type', 'application/json',
+    'Authorization', 'Bearer ' || shared_secret
+  );
+
+  PERFORM net.http_post(
+    url := edge_function_url,
+    body := payload,
+    headers := request_headers
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+-- ============================================================
+-- 2. Triggers on friendships
+-- ============================================================
+
+DROP TRIGGER IF EXISTS notify_friend_request_insert ON public.friendships;
+CREATE TRIGGER notify_friend_request_insert
+  AFTER INSERT ON public.friendships
+  FOR EACH ROW
+  WHEN (NEW.status = 'pending')
+  EXECUTE FUNCTION notify_friend_request();
+
+DROP TRIGGER IF EXISTS notify_friend_request_update ON public.friendships;
+CREATE TRIGGER notify_friend_request_update
+  AFTER UPDATE OF status ON public.friendships
+  FOR EACH ROW
+  WHEN (OLD.status IS DISTINCT FROM NEW.status AND NEW.status = 'accepted')
+  EXECUTE FUNCTION notify_friend_request();

--- a/supabase/migrations/20260501120000_call_status_failed.sql
+++ b/supabase/migrations/20260501120000_call_status_failed.sql
@@ -1,0 +1,14 @@
+-- Add 'failed' to call_status enum.
+--
+-- Background: Tidigare användes 'missed' både för "callee svarade inte i tid"
+-- och för "samtalet kom aldrig fram" (token-fail, network-fail, agora-init-fail).
+-- Det vilseledde Owner och chatten — ett samtal som aldrig nådde mottagaren
+-- visades som missat.
+--
+-- 'failed' separerar de fallen:
+--   missed = callee nåddes (push gick ut, ringsignal triggad) men svarade inte
+--   failed = samtalet kom aldrig fram till callee (init-fel av olika slag)
+--
+-- ALTER TYPE ... ADD VALUE körs utanför explicit transaktionsblock (Postgres
+-- tillåter detta sedan 12), så ingen DROP/recreate behövs.
+ALTER TYPE call_status ADD VALUE IF NOT EXISTS 'failed';


### PR DESCRIPTION
## Summary

Genomgång av alla öppna alva-issues på boarden. Sex issues stängda i denna PR.

| Issue | Beskrivning |
|-------|-------------|
| #14 | Audit `.single()` → `.maybeSingle()` där rad inte garanterad. 15 filer (services, contexts, hooks, pages + edge functions). Insert+RETURNING lämnas oförändrat. |
| #5  | Emojis på iOS — globala font-stacken saknade `Apple Color Emoji` / `Segoe UI Emoji` / `Noto Color Emoji` som fallback. Tillagt sist i stacken så textfont används för bokstäver och emoji-fonten används per glyph. |
| #4  | Reply-preview — citatrutan i input-toolbar fungerade redan, men onClick på citat i bubble var no-op. Implementerat scroll-to-message + 1.6s highlight-flash via CSS-animation. |
| #6  | Owner/Super-toggle för push-notiser per Texter. Migration `texter_settings.push_enabled BOOLEAN DEFAULT true` + UI-toggle + check i `send-push` + `call-push`. Texter ser banner i Settings när teamet stängt av push. i18n på sv/en/no/da/fi. |
| #7  | Push-notiser för vänförfrågningar. Ny edge function `friend-push` (Bearer-auth, FCM/APNs, samma vault-secret som send-push). DB-trigger på friendships INSERT/UPDATE som postar via pg_net. Auto-team-friendships skippas. |
| #15 | Refaktorera call_log-livscykel — separat `failed`-status. Token-fail markerar nu loggen `failed` + postar systemmeddelande istället för pessimistisk `delete + tystnad`. UI-skillnad: orange warning-ikon. |

Bump till versionCode 30 / versionName 1.5.12.

## Deploy före build

**Migrations** (push i ordning):
- `20260501100000_texter_push_enabled.sql`
- `20260501110000_friend_push_triggers.sql`
- `20260501120000_call_status_failed.sql`

**Edge functions** att deploya:
- `friend-push` (ny)
- `send-push` (push_enabled-respekt)
- `call-push` (push_enabled-respekt)
- `agora-token` (.maybeSingle())
- `send-invitation` (.maybeSingle())
- `create-invited-user` (.maybeSingle())

## Test plan

- [ ] Pusha de tre migrations till prod-Supabase (kontrollera att `pg_net_shared_secret`-vault redan finns)
- [ ] Deploya alla berörda edge functions
- [ ] Trigga Codemagic Android-build manuellt (auto-trigger är ostabilt)
- [ ] Ladda upp AAB till Play Internal Testing
- [ ] iOS: testa emoji-rendering i chatt
- [ ] Reply: tryck på citat → scroll + flash
- [ ] Owner: stäng av push för Texter → Texter ser banner i Settings, FCM uteblir
- [ ] Skicka vänförfrågan → push till mottagaren
- [ ] Acceptera vänförfrågan → push till avsändaren
- [ ] Token-fail (testa offline): call_log markeras `failed`, chat visar orange ikon

🤖 Generated with [Claude Code](https://claude.com/claude-code)