### PR TITLE
fix(revenuecat): disable Supabase JWT gateway on webhook

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -364,6 +364,12 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# RevenueCat posts to this webhook with its own Bearer secret (verified
+# inside the function). Disable Supabase JWT verification at the gateway
+# so RC's request actually reaches the function.
+[functions.revenuecat-webhook]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327


### PR DESCRIPTION
## Bakgrund — kritiskt fynd

Vid pre-launch-verifiering av RevenueCat upptäckte jag att webhook-funktionen aldrig blivit nåd av RC. Supabase Edge Functions verifierar default en giltig Supabase-JWT vid gatewayen — RC skickar bara sin egen Bearer-token, så alla webhook-posts har returnerats 401 från gatewayen, INNAN funktionens kod exekverats.

## Konsekvens i nuläget

- `teams.plan` har aldrig uppdaterats från servern via RC events
- Server-side fallback som audit fix #20 förutsatte fanns inte i praktiken
- Klienter på jailbreakade enheter kunde spoofa `customerInfo` utan motkontroll

## Fixen

Lägg till `[functions.revenuecat-webhook]` med `verify_jwt = false` i `supabase/config.toml`. Funktionen har redan egen constant-time Bearer-auth mot 36-tecken random `REVENUECAT_WEBHOOK_AUTH`, så gateway-skyddet behövs inte och blockerade endast den legitima trafiken.

## Verifierat end-to-end

| Test | Förväntat | Faktiskt |
|---|---|---|
| GET | 405 | 405 ✓ |
| POST utan auth | 401 | 401 ✓ |
| POST med fel auth | 401 | 401 ✓ |
| POST med rätt auth + TEST event | 200 skipped | 200 skipped ✓ |
| POST med rätt auth + saknad payload | 400 | 400 ✓ |

Funktionen är redan re-deployad till `qrrorlxocpxvqcfdipbq` så fixen är aktiv i produktion. Den här PR:n committar bara konfigurationsändringen så den inte tappas vid framtida deploys.

## Test plan

- [x] Webhook svarar 200 på legitima RC-posts
- [x] Webhook svarar 401 på posts utan korrekt secret
- [ ] Apple sandbox-test av hel livscykel — kräver fysisk iPhone, körs av Erik/Victor med v1.5.12 i TestFlight