### PR TITLE
fix(v1.5.13): batch — push #32, reply #33, reactions #34, emoji #35, perf TOP 3

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.zemichat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 30
-        versionName "1.5.12"
+        versionCode 31
+        versionName "1.5.13"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
             debugSymbolLevel 'FULL'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,6 +65,13 @@
             </intent-filter>
         </service>
 
+        <!-- Issue #32: route FCM messages without an explicit channel_id to
+             the high-importance "messages_v2" channel so Android shows heads-up
+             banners with text preview by default. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="messages_v2" />
+
         <!-- Broadcast receiver for declining calls from notification -->
         <receiver
             android:name=".CallDismissReceiver"

--- a/android/app/src/main/java/com/zemichat/app/ZemichatMessagingService.java
+++ b/android/app/src/main/java/com/zemichat/app/ZemichatMessagingService.java
@@ -32,12 +32,18 @@ public class ZemichatMessagingService extends FirebaseMessagingService {
     // a new id is the only way to ship updated audio attributes without
     // an uninstall.
     private static final String CHANNEL_ID_CALLS = "incoming_calls_v2";
+    // Bumped to v2 for issue #32: previous "messages" channel was created
+    // with default importance and is immutable — re-create as v2 to upgrade
+    // to IMPORTANCE_HIGH so heads-up banners with text preview show on
+    // Android (matches WhatsApp behaviour).
+    public static final String CHANNEL_ID_MESSAGES = "messages_v2";
     private static final int CALL_NOTIFICATION_ID = 9001;
 
     @Override
     public void onCreate() {
         super.onCreate();
         createCallNotificationChannel();
+        createMessagesNotificationChannel();
     }
 
     @Override
@@ -147,6 +153,24 @@ public class ZemichatMessagingService extends FirebaseMessagingService {
         NotificationManager notificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.cancel(CALL_NOTIFICATION_ID);
+    }
+
+    private void createMessagesNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID_MESSAGES,
+                    "Meddelanden",
+                    NotificationManager.IMPORTANCE_HIGH
+            );
+            channel.setDescription("Push-notiser för chattmeddelanden");
+            channel.enableVibration(true);
+            channel.setLockscreenVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+
+            NotificationManager nm = getSystemService(NotificationManager.class);
+            if (nm != null) {
+                nm.createNotificationChannel(channel);
+            }
+        }
     }
 
     private void createCallNotificationChannel() {

--- a/src/components/chat/ChatInputToolbar.tsx
+++ b/src/components/chat/ChatInputToolbar.tsx
@@ -152,8 +152,14 @@ const ChatInputToolbar: React.FC<ChatInputToolbarProps> = ({
   return (
     <div className="chat-input-toolbar">
       {/* Smiley / Emoji toggle */}
+      {/* Issue #35: iOS Safari/WKWebView fires blur on the textarea before
+          our click lands on the emoji button when the keyboard is open, so
+          the panel never opens. preventDefault on mousedown/touchstart keeps
+          focus on the textarea long enough for the click to register. */}
       <button
         className={`toolbar-icon-btn ${isEmojiPanelOpen ? 'active' : ''}`}
+        onMouseDown={(e) => e.preventDefault()}
+        onTouchStart={(e) => e.preventDefault()}
         onClick={onToggleEmojiPanel}
         disabled={isSending}
         aria-label={t('chat.emojis')}

--- a/src/components/chat/ChatSearchModal.tsx
+++ b/src/components/chat/ChatSearchModal.tsx
@@ -197,7 +197,7 @@ export const ChatSearchModal: React.FC<ChatSearchModalProps> = ({
                 >
                   <IonAvatar slot="start" className="result-avatar">
                     {result.sender?.avatar_url ? (
-                      <img src={result.sender.avatar_url} alt="" />
+                      <img src={result.sender.avatar_url} alt="" loading="lazy" decoding="async" />
                     ) : (
                       <div
                         className="avatar-placeholder"

--- a/src/components/chat/ForwardPicker.tsx
+++ b/src/components/chat/ForwardPicker.tsx
@@ -149,7 +149,7 @@ const ForwardPicker: React.FC<ForwardPickerProps> = ({
                 >
                   <IonAvatar slot="start" className="forward-picker-avatar">
                     {avatarUrl ? (
-                      <img src={avatarUrl} alt="" />
+                      <img src={avatarUrl} alt="" loading="lazy" decoding="async" />
                     ) : (
                       <div className="forward-avatar-placeholder">
                         {initial}

--- a/src/components/chat/ImageMessage.tsx
+++ b/src/components/chat/ImageMessage.tsx
@@ -31,7 +31,9 @@ const ImageMessage: React.FC<ImageMessageProps> = ({
 
   // Resolve thumbnail (in-bubble) and current fullscreen image to signed URLs.
   // Storage path -> signed URL with 1h TTL (audit fix #18).
-  const thumbUrl = useSignedMediaUrl(mediaUrl);
+  // Thumb requests a 600w/q75 CDN variant — full-size 3-4MB source
+  // never goes down the wire just to fill a 200px bubble (audit #36-17).
+  const thumbUrl = useSignedMediaUrl(mediaUrl, { width: 600, quality: 75 });
   const [resolvedGalleryUrl, setResolvedGalleryUrl] = useState<string | null>(null);
 
   // Pinch-to-zoom state
@@ -90,13 +92,15 @@ const ImageMessage: React.FC<ImageMessageProps> = ({
     : mediaUrl;
 
   // Resolve the active gallery item to a signed URL whenever it changes.
+  // Fullscreen view gets a 1600w variant — large enough for retina but
+  // still avoids shipping the full-resolution source (audit #36-17).
   useEffect(() => {
     if (!isFullscreen || !currentRawUrl) {
       setResolvedGalleryUrl(null);
       return;
     }
     let cancelled = false;
-    resolveMediaUrl(currentRawUrl).then((url) => {
+    resolveMediaUrl(currentRawUrl, { width: 1600, quality: 85 }).then((url) => {
       if (!cancelled) setResolvedGalleryUrl(url);
     });
     return () => {
@@ -322,6 +326,8 @@ const ImageMessage: React.FC<ImageMessageProps> = ({
             src={thumbUrl}
             alt={metadata?.fileName || 'Image'}
             className={`message-image ${isLoading ? 'hidden' : ''}`}
+            loading="lazy"
+            decoding="async"
             onLoad={handleLoad}
             onError={handleError}
           />
@@ -371,6 +377,7 @@ const ImageMessage: React.FC<ImageMessageProps> = ({
             src={currentUrl || ''}
             alt={metadata?.fileName || 'Image'}
             className="fullscreen-image"
+            decoding="async"
             style={{
               transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
               transition: isPinchingRef.current || isPanningRef.current ? 'none' : 'transform 0.2s ease-out',

--- a/src/components/chat/MentionAutocomplete.tsx
+++ b/src/components/chat/MentionAutocomplete.tsx
@@ -32,7 +32,7 @@ const MentionAutocomplete: React.FC<MentionAutocompleteProps> = ({
         >
           <div className="mention-avatar">
             {m.user?.avatar_url ? (
-              <img src={m.user.avatar_url} alt="" />
+              <img src={m.user.avatar_url} alt="" loading="lazy" decoding="async" />
             ) : (
               <span className="mention-initial">
                 {(m.user?.display_name || '?').charAt(0).toUpperCase()}

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -222,6 +222,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
               alt="GIF"
               className="message-gif"
               loading="lazy"
+              decoding="async"
               style={gifMeta?.width && gifMeta?.height ? {
                 aspectRatio: `${gifMeta.width} / ${gifMeta.height}`,
               } : undefined}

--- a/src/components/chat/QuotedMessage.tsx
+++ b/src/components/chat/QuotedMessage.tsx
@@ -16,9 +16,9 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
 
   const getPreview = (): string => {
     if (message.content) {
-      return message.content.length > 100
-        ? message.content.slice(0, 100) + '...'
-        : message.content;
+      // CSS handles 3-line clamp + ellipsis (overflow-wrap + line-clamp).
+      // Don't pre-truncate here — that broke wrapping for long words.
+      return message.content;
     }
 
     switch (message.type) {
@@ -94,6 +94,7 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
           display: flex;
           flex-direction: column;
           min-width: 0;
+          flex: 1 1 0;
           overflow: hidden;
         }
 
@@ -113,8 +114,17 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
 
         .quote-text {
           font-size: 0.8rem;
+          line-height: 1.3;
           opacity: 0.8;
-          white-space: nowrap;
+          /* WhatsApp-style wrapping: max 3 rows then ellipsis.
+             overflow-wrap:anywhere + word-break:break-word handle long
+             URLs / unbroken strings without overflowing the bubble. */
+          overflow-wrap: anywhere;
+          word-break: break-word;
+          display: -webkit-box;
+          -webkit-line-clamp: 3;
+          line-clamp: 3;
+          -webkit-box-orient: vertical;
           overflow: hidden;
           text-overflow: ellipsis;
         }

--- a/src/components/common/GroupAvatar.tsx
+++ b/src/components/common/GroupAvatar.tsx
@@ -23,7 +23,13 @@ const GroupAvatar: React.FC<GroupAvatarProps> = ({ members, size = 48 }) => {
     return (
       <div style={{ width: size, height: size, borderRadius: '50%', overflow: 'hidden' }}>
         {m?.avatar_url ? (
-          <img src={m.avatar_url} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+          <img
+            src={m.avatar_url}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          />
         ) : (
           <div
             style={{
@@ -66,6 +72,8 @@ const GroupAvatar: React.FC<GroupAvatarProps> = ({ members, size = 48 }) => {
             <img
               src={m.avatar_url}
               alt=""
+              loading="lazy"
+              decoding="async"
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             />
           ) : (

--- a/src/components/wall/WallPost.tsx
+++ b/src/components/wall/WallPost.tsx
@@ -53,7 +53,13 @@ const WallPostCard: React.FC<WallPostCardProps> = ({
   const canDelete = !isDeleted && (isAuthor || isOwner);
 
   // chat-media is private — resolve storage path to signed URL (audit fix #18).
-  const resolvedImageUrl = useSignedMediaUrl(post.media_url);
+  // Inline post image gets a 1200w/q80 CDN variant. The fullscreen modal
+  // and inline view both reuse this signed URL — keep transform consistent
+  // so the cache hits (audit fix #36-17).
+  const resolvedImageUrl = useSignedMediaUrl(post.media_url, {
+    width: 1200,
+    quality: 80,
+  });
 
   const formatTime = (dateStr: string): string => {
     const date = new Date(dateStr);
@@ -141,7 +147,7 @@ const WallPostCard: React.FC<WallPostCardProps> = ({
       <div className="post-header">
         <IonAvatar className="post-avatar">
           {post.author?.avatar_url ? (
-            <img src={post.author.avatar_url} alt="" />
+            <img src={post.author.avatar_url} alt="" loading="lazy" decoding="async" />
           ) : (
             <div className="avatar-placeholder">
               {(post.author?.display_name || '?').charAt(0).toUpperCase()}
@@ -178,7 +184,13 @@ const WallPostCard: React.FC<WallPostCardProps> = ({
       {/* Image */}
       {post.media_url && resolvedImageUrl && (
         <div className="post-image-container" onClick={() => setShowFullImage(true)}>
-          <img src={resolvedImageUrl} alt="" className="post-image" />
+          <img
+            src={resolvedImageUrl}
+            alt=""
+            className="post-image"
+            loading="lazy"
+            decoding="async"
+          />
         </div>
       )}
 
@@ -243,7 +255,12 @@ const WallPostCard: React.FC<WallPostCardProps> = ({
       {/* Fullscreen image modal */}
       <IonModal isOpen={showFullImage} onDidDismiss={() => setShowFullImage(false)}>
         <div className="fullscreen-image-wrapper" onClick={() => setShowFullImage(false)}>
-          <img src={resolvedImageUrl || ''} alt="" className="fullscreen-image" />
+          <img
+            src={resolvedImageUrl || ''}
+            alt=""
+            className="fullscreen-image"
+            decoding="async"
+          />
         </div>
       </IonModal>
 

--- a/src/contexts/CallContext.tsx
+++ b/src/contexts/CallContext.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   useRef,
   type ReactNode,
 } from 'react';
@@ -971,26 +972,51 @@ export function CallProvider({ children }: CallProviderProps) {
   // CONTEXT VALUE
   // ============================================================
 
-  const value: CallContextValue = {
-    activeCall,
-    incomingCall,
-    isAgoraReady,
-    callDuration,
-    callError,
-    localVideoTrack: videoTrackRef.current,
-    screenShareTrack: screenTrackRef.current,
-    remoteUsers,
-    initiateCall,
-    answerCall,
-    declineCall,
-    endCall,
-    toggleMute,
-    toggleSpeaker,
-    toggleVideo,
-    toggleScreenShare,
-    toggleMinimize,
-    clearCallError,
-  };
+  // Audit fix #36-5: memo:a context-värdet. Notera att videoTrackRef.current
+  // och screenTrackRef.current är ref-värden som ändras utan re-render — de
+  // räknas inte som egentliga "props" och utesluts som deps. Components som
+  // behöver färska track-referenser ska re-rendrera via callDuration eller
+  // remoteUsers-state.
+  const value: CallContextValue = useMemo(
+    () => ({
+      activeCall,
+      incomingCall,
+      isAgoraReady,
+      callDuration,
+      callError,
+      localVideoTrack: videoTrackRef.current,
+      screenShareTrack: screenTrackRef.current,
+      remoteUsers,
+      initiateCall,
+      answerCall,
+      declineCall,
+      endCall,
+      toggleMute,
+      toggleSpeaker,
+      toggleVideo,
+      toggleScreenShare,
+      toggleMinimize,
+      clearCallError,
+    }),
+    [
+      activeCall,
+      incomingCall,
+      isAgoraReady,
+      callDuration,
+      callError,
+      remoteUsers,
+      initiateCall,
+      answerCall,
+      declineCall,
+      endCall,
+      toggleMute,
+      toggleSpeaker,
+      toggleVideo,
+      toggleScreenShare,
+      toggleMinimize,
+      clearCallError,
+    ],
+  );
 
   return (
     <CallContext.Provider value={value}>

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from 'react';
 import { useAuthContext } from './AuthContext';
 import { supabase } from '../services/supabase';
 import {
@@ -158,19 +158,29 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     }
   }, [totalUnreadMessages]);
 
+  // Audit fix #36-5: memo:a context-värdet så provider inte invalida 30+
+  // konsumenter varje render.
+  const value = useMemo(
+    () => ({
+      unreadChatCount,
+      totalUnreadMessages,
+      pendingFriendRequests,
+      hasNewWallPosts: wallHasNew,
+      refreshCounts,
+      markWallVisited,
+    }),
+    [
+      unreadChatCount,
+      totalUnreadMessages,
+      pendingFriendRequests,
+      wallHasNew,
+      refreshCounts,
+      markWallVisited,
+    ],
+  );
+
   return (
-    <NotificationContext.Provider
-      value={{
-        unreadChatCount,
-        totalUnreadMessages,
-        pendingFriendRequests,
-        hasNewWallPosts: wallHasNew,
-        refreshCounts,
-        markWallVisited,
-      }}
-    >
-      {children}
-    </NotificationContext.Provider>
+    <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>
   );
 }
 

--- a/src/contexts/SubscriptionContext.tsx
+++ b/src/contexts/SubscriptionContext.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   type ReactNode,
 } from 'react';
 import { useAuthContext } from './AuthContext';
@@ -242,26 +243,49 @@ export function SubscriptionProvider({ children }: SubscriptionProviderProps) {
   // CONTEXT VALUE
   // ============================================================
 
-  const value: SubscriptionContextValue = {
-    status,
-    offerings,
-    currentOffering,
-    isLoading,
-    error,
-    currentPlan,
-    isTrialActive,
-    isTrialExpired,
-    trialDaysLeft,
-    canUseFeature,
-    refreshStatus,
-    purchase,
-    restore,
-    startTrial,
-    showPaywall,
-    hidePaywall,
-    isPaywallVisible,
-    paywallFeature,
-  };
+  // Audit fix #36-5: memo:a context-värdet.
+  const value: SubscriptionContextValue = useMemo(
+    () => ({
+      status,
+      offerings,
+      currentOffering,
+      isLoading,
+      error,
+      currentPlan,
+      isTrialActive,
+      isTrialExpired,
+      trialDaysLeft,
+      canUseFeature,
+      refreshStatus,
+      purchase,
+      restore,
+      startTrial,
+      showPaywall,
+      hidePaywall,
+      isPaywallVisible,
+      paywallFeature,
+    }),
+    [
+      status,
+      offerings,
+      currentOffering,
+      isLoading,
+      error,
+      currentPlan,
+      isTrialActive,
+      isTrialExpired,
+      trialDaysLeft,
+      canUseFeature,
+      refreshStatus,
+      purchase,
+      restore,
+      startTrial,
+      showPaywall,
+      hidePaywall,
+      isPaywallVisible,
+      paywallFeature,
+    ],
+  );
 
   return (
     <SubscriptionContext.Provider value={value}>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useMemo, type ReactNode } from 'react';
 
 export type ThemeName = 'dark' | 'light' | 'ocean' | 'sunset' | 'forest' | 'candy';
 
@@ -164,11 +164,18 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     setThemeState(name);
   };
 
-  return (
-    <ThemeContext.Provider value={{ theme, setTheme, availableThemes: Object.keys(THEMES) as ThemeName[] }}>
-      {children}
-    </ThemeContext.Provider>
+  // Audit fix #36-5: memo:a context-värdet så provider inte invalida 30+
+  // konsumenter varje render.
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      availableThemes: Object.keys(THEMES) as ThemeName[],
+    }),
+    [theme],
   );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 };
 
 export default ThemeContext;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type { User as SupabaseUser, Session } from '@supabase/supabase-js';
 import { getSession, onAuthStateChange, signOut as authSignOut } from '../services/auth';
 import { getMyProfile, hasTeamProfile } from '../services/team';
@@ -165,17 +165,35 @@ export function useAuth(): AuthState {
     (profile.is_active === false || profile.is_paused === true)
   );
 
-  return {
-    isLoading,
-    isAuthenticated: !!authUser,
-    authUser,
-    session,
-    profile,
-    hasProfile,
-    pushPermission,
-    sosOnly,
-    signOut,
-    refreshProfile,
-    initializePush,
-  };
+  // Audit fix #36-5: memo:a returvärdet så context-konsumenter inte får ny
+  // referens varje render. Utan detta invaliderar AuthContext.Provider alla
+  // 30+ konsumenter (ChatView, ChatList, MessageBubbles m.fl.) varje gång
+  // någon liten state-bit i hooken förändras (typing-tick, presence-tick).
+  return useMemo(
+    () => ({
+      isLoading,
+      isAuthenticated: !!authUser,
+      authUser,
+      session,
+      profile,
+      hasProfile,
+      pushPermission,
+      sosOnly,
+      signOut,
+      refreshProfile,
+      initializePush,
+    }),
+    [
+      isLoading,
+      authUser,
+      session,
+      profile,
+      hasProfile,
+      pushPermission,
+      sosOnly,
+      signOut,
+      refreshProfile,
+      initializePush,
+    ],
+  );
 }

--- a/src/hooks/useSignedMediaUrl.ts
+++ b/src/hooks/useSignedMediaUrl.ts
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
-import { resolveMediaUrl } from '../services/storage';
+import {
+  getCachedMediaUrl,
+  resolveMediaUrl,
+  type MediaTransform,
+} from '../services/storage';
 
 /**
  * Resolve a chat-media storage path (or legacy public URL) to a short-lived
@@ -10,13 +14,37 @@ import { resolveMediaUrl } from '../services/storage';
  * URL. This hook handles both new path values and legacy http(s):// URLs
  * (which it returns unchanged).
  *
- * Returns `null` while loading, then either the signed URL string or `null`
- * if signing failed.
+ * Pass `transform` to request a Storage-side resized variant (thumbnails,
+ * avatars) instead of the full-size source. The cache is keyed per
+ * path + transform, so the same source can be served at multiple sizes
+ * without re-signing (audit fix #36-17).
+ *
+ * Initialises from the in-memory signed-URL cache to avoid flicker on
+ * rerender — if a fresh signed URL already exists for this path, useState
+ * starts with it instead of null (audit fix #36-18).
+ *
+ * Returns `null` while loading, then either the signed URL string or
+ * `null` if signing failed.
  */
 export function useSignedMediaUrl(
-  pathOrUrl: string | null | undefined
+  pathOrUrl: string | null | undefined,
+  transform?: MediaTransform
 ): string | null {
-  const [resolved, setResolved] = useState<string | null>(null);
+  // Stable serialisation so a fresh `{width:96}` object on every render
+  // doesn't retrigger the effect or invalidate the cached state.
+  const transformKey = transform
+    ? JSON.stringify({
+        w: transform.width,
+        h: transform.height,
+        q: transform.quality,
+        r: transform.resize,
+        f: transform.format,
+      })
+    : '';
+
+  const [resolved, setResolved] = useState<string | null>(() =>
+    getCachedMediaUrl(pathOrUrl, transform)
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -25,10 +53,19 @@ export function useSignedMediaUrl(
       return;
     }
 
-    // Reset while we resolve to avoid showing the previous image.
-    setResolved(null);
+    // If the cache already has a fresh entry, surface it synchronously
+    // (covers the case where pathOrUrl changed between renders to
+    // something already cached).
+    const cached = getCachedMediaUrl(pathOrUrl, transform);
+    if (cached) {
+      setResolved(cached);
+      return;
+    }
 
-    resolveMediaUrl(pathOrUrl).then((url) => {
+    // Don't reset to null when we already had a value — that's what
+    // caused the flicker. We just kick off the resolution and overwrite
+    // when it returns.
+    resolveMediaUrl(pathOrUrl, transform).then((url) => {
       if (!cancelled) {
         setResolved(url);
       }
@@ -37,7 +74,10 @@ export function useSignedMediaUrl(
     return () => {
       cancelled = true;
     };
-  }, [pathOrUrl]);
+    // transformKey carries the transform identity; transform itself is
+    // not in deps to avoid re-running on every parent render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathOrUrl, transformKey]);
 
   return resolved;
 }

--- a/src/pages/ChatList.tsx
+++ b/src/pages/ChatList.tsx
@@ -300,7 +300,7 @@ const ChatList: React.FC = () => {
                 size={48}
               />
             ) : avatar ? (
-              <img src={avatar} alt={displayName} />
+              <img src={avatar} alt={displayName} loading="lazy" decoding="async" />
             ) : (
               <div className="avatar-placeholder" style={{ background: avatarGradient }}>{initial}</div>
             )}
@@ -809,7 +809,7 @@ const ChatList: React.FC = () => {
             <div className="preview-header-row">
               <div className="preview-avatar">
                 {getChatAvatar(previewChat) ? (
-                  <img src={getChatAvatar(previewChat)!} alt="" />
+                  <img src={getChatAvatar(previewChat)!} alt="" loading="lazy" decoding="async" />
                 ) : (
                   <div
                     className="avatar-placeholder-small"

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -22,6 +22,12 @@ export interface SendMessageResult {
   error: Error | null;
 }
 
+// Module-level cache of senders we've already resolved. Keyed by user id.
+// Audit fix #36-8: avoids an extra round-trip per realtime INSERT/UPDATE
+// event — the payload already contains the message row, we only need to
+// attach sender metadata, which barely changes during a session.
+const senderCache = new Map<string, User>();
+
 /**
  * Get messages for a chat.
  */
@@ -53,6 +59,12 @@ export async function getChatMessages(
     }
 
     const messages = (data || []) as unknown as MessageWithSender[];
+
+    // Audit #36-8: prime the sender cache so subscribeToMessages doesn't
+    // need an extra round-trip for the first event from each user.
+    for (const msg of messages) {
+      if (msg.sender?.id) senderCache.set(msg.sender.id, msg.sender);
+    }
 
     // Fetch reply_to messages separately for messages that have replies
     const replyIds = messages
@@ -138,15 +150,55 @@ export async function sendMessage({
   }
 }
 
+async function getSenderCached(senderId: string): Promise<User | null> {
+  const cached = senderCache.get(senderId);
+  if (cached) return cached;
+  const { data } = await supabase
+    .from('users')
+    .select('*')
+    .eq('id', senderId)
+    .maybeSingle();
+  if (data) {
+    const user = data as unknown as User;
+    senderCache.set(senderId, user);
+    return user;
+  }
+  return null;
+}
+
 /**
  * Subscribe to new and updated messages in a chat.
  * Returns an unsubscribe function.
+ *
+ * Audit fix #36-8: previously each realtime event triggered an extra
+ * SELECT against `messages` to attach the sender. The realtime payload
+ * already contains the full row — we now use it directly and only fetch
+ * sender data once per user (cached).
  */
 export function subscribeToMessages(
   chatId: string,
   onMessage: (message: MessageWithSender) => void,
   onUpdate?: (message: MessageWithSender) => void
 ): () => void {
+  const handleEvent = async (
+    payload: { new: Record<string, unknown> },
+    callback: (m: MessageWithSender) => void,
+  ) => {
+    const row = payload.new as unknown as Message;
+    const senderId = row.sender_id;
+    const sender = senderId ? await getSenderCached(senderId) : null;
+    if (!sender) {
+      // Sender lookup failed — fall back to a stub so the UI can still
+      // render the message rather than dropping it.
+      callback({
+        ...row,
+        sender: { id: senderId, display_name: '', avatar_url: null } as unknown as User,
+      });
+      return;
+    }
+    callback({ ...row, sender });
+  };
+
   const channel: RealtimeChannel = supabase
     .channel(`messages:${chatId}`)
     .on(
@@ -157,20 +209,7 @@ export function subscribeToMessages(
         table: 'messages',
         filter: `chat_id=eq.${chatId}`,
       },
-      async (payload) => {
-        const { data } = await supabase
-          .from('messages')
-          .select(`
-            *,
-            sender:users!messages_sender_id_fkey (*)
-          `)
-          .eq('id', payload.new.id)
-          .maybeSingle();
-
-        if (data) {
-          onMessage(data as unknown as MessageWithSender);
-        }
-      }
+      (payload) => handleEvent(payload, onMessage),
     )
     .on(
       'postgres_changes',
@@ -180,27 +219,27 @@ export function subscribeToMessages(
         table: 'messages',
         filter: `chat_id=eq.${chatId}`,
       },
-      async (payload) => {
+      (payload) => {
         if (!onUpdate) return;
-        const { data } = await supabase
-          .from('messages')
-          .select(`
-            *,
-            sender:users!messages_sender_id_fkey (*)
-          `)
-          .eq('id', payload.new.id)
-          .maybeSingle();
-
-        if (data) {
-          onUpdate(data as unknown as MessageWithSender);
-        }
-      }
+        handleEvent(payload, onUpdate);
+      },
     )
     .subscribe();
 
   return () => {
     supabase.removeChannel(channel);
   };
+}
+
+/**
+ * Pre-warm the sender cache with users we already know about (e.g. chat
+ * members). This avoids the first-message-per-user round-trip in
+ * `subscribeToMessages`.
+ */
+export function primeSenderCache(users: User[]): void {
+  for (const u of users) {
+    if (u?.id) senderCache.set(u.id, u);
+  }
 }
 
 /**

--- a/src/services/reaction.ts
+++ b/src/services/reaction.ts
@@ -14,6 +14,10 @@ export interface GroupedReaction {
 
 /**
  * Add a reaction to a message.
+ *
+ * A user is allowed at most one reaction per message (issue #34, enforced by
+ * the (message_id, user_id) unique constraint). If the user already has a
+ * different reaction on this message it is replaced with the new emoji.
  */
 export async function addReaction(
   messageId: string,
@@ -28,6 +32,20 @@ export async function addReaction(
       return { reaction: null, error: new Error('Not authenticated') };
     }
 
+    // Remove any existing reaction by this user on this message first, so we
+    // can cleanly insert the new emoji. We do delete+insert (rather than
+    // upsert with ON CONFLICT DO UPDATE) because the message_reactions RLS
+    // policies only cover INSERT/DELETE — there is no UPDATE policy.
+    const { error: deleteError } = await supabase
+      .from('message_reactions')
+      .delete()
+      .eq('message_id', messageId)
+      .eq('user_id', user.id);
+
+    if (deleteError) {
+      return { reaction: null, error: new Error(deleteError.message) };
+    }
+
     const { data, error } = await supabase
       .from('message_reactions')
       .insert({
@@ -39,9 +57,11 @@ export async function addReaction(
       .single();
 
     if (error) {
-      // Handle unique constraint violation (already reacted with this emoji)
+      // Should not happen now that we delete first, but keep the guard so a
+      // race (two near-simultaneous reactions from the same user) surfaces a
+      // sensible error instead of a raw 23505.
       if (error.code === '23505') {
-        return { reaction: null, error: new Error('Already reacted with this emoji') };
+        return { reaction: null, error: new Error('Already reacted to this message') };
       }
       return { reaction: null, error: new Error(error.message) };
     }
@@ -91,7 +111,16 @@ export async function removeReaction(
 }
 
 /**
- * Toggle a reaction on a message (add if not present, remove if present).
+ * Toggle a reaction on a message.
+ *
+ * Issue #34: Each user may have at most one reaction per message. The
+ * semantics are WhatsApp/iMessage style:
+ *  - No existing reaction          → add the new emoji.
+ *  - Existing reaction, same emoji → remove it (untoggle).
+ *  - Existing reaction, different  → replace it with the new emoji.
+ *
+ * `added` is true when the user ends up with a reaction on the message, and
+ * false when the call resulted in removal.
  */
 export async function toggleReaction(
   messageId: string,
@@ -106,22 +135,26 @@ export async function toggleReaction(
       return { added: false, error: new Error('Not authenticated') };
     }
 
-    // Check if reaction exists
+    // Look up the user's existing reaction on this message (any emoji).
     const { data: existing } = await supabase
       .from('message_reactions')
-      .select('id')
+      .select('id, emoji')
       .eq('message_id', messageId)
       .eq('user_id', user.id)
-      .eq('emoji', emoji)
       .maybeSingle();
 
-    if (existing) {
+    const typed = existing as unknown as { id: string; emoji: string } | null;
+
+    if (typed && typed.emoji === emoji) {
+      // Same emoji — untoggle.
       const { error } = await removeReaction(messageId, emoji);
       return { added: false, error };
-    } else {
-      const { error } = await addReaction(messageId, emoji);
-      return { added: true, error };
     }
+
+    // Either no reaction yet, or a different emoji we should replace.
+    // addReaction() handles both cases (it deletes any existing row first).
+    const { error } = await addReaction(messageId, emoji);
+    return { added: true, error };
   } catch (err) {
     return {
       added: false,

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -392,17 +392,40 @@ export async function uploadAvatar(
 }
 
 /**
+ * Supabase Storage Image Transformation options.
+ *
+ * Resizes/recompresses on the CDN edge so we don't ship the full-size
+ * source down to thumbnails (audit fix #36-17). Only applied to images
+ * via createSignedUrl({ transform }).
+ */
+export interface MediaTransform {
+  width?: number;
+  height?: number;
+  quality?: number;
+  resize?: 'cover' | 'contain' | 'fill';
+  format?: 'origin';
+}
+
+/**
  * Get a signed URL for accessing a private file.
  * Useful when the bucket is private.
+ *
+ * Pass `transform` to apply Supabase Image Transformation (Pro feature).
+ * Storage returns a smaller, recompressed version for thumbnails.
  */
 export async function getSignedUrl(
   path: string,
-  expiresIn = SIGNED_URL_TTL_SECONDS
+  expiresIn = SIGNED_URL_TTL_SECONDS,
+  transform?: MediaTransform
 ): Promise<{ url: string | null; error: Error | null }> {
   try {
     const { data, error } = await supabase.storage
       .from(BUCKET_NAME)
-      .createSignedUrl(path, expiresIn);
+      .createSignedUrl(
+        path,
+        expiresIn,
+        transform ? { transform } : undefined
+      );
 
     if (error) {
       return { url: null, error: new Error(error.message) };
@@ -468,48 +491,99 @@ function isAbsoluteUrl(value: string): boolean {
 }
 
 /**
+ * Cache key includes transform options so a 96px avatar request and a
+ * 600px thumb request for the same path don't clobber each other.
+ */
+function cacheKey(path: string, transform?: MediaTransform): string {
+  if (!transform) return path;
+  const t = [
+    transform.width ?? '',
+    transform.height ?? '',
+    transform.quality ?? '',
+    transform.resize ?? '',
+    transform.format ?? '',
+  ].join(':');
+  return `${path}#${t}`;
+}
+
+/**
  * Resolve a chat-media storage path to a signed URL.
  *
  * Accepts:
  *   - storage paths like "userId/chatId/123_pic.jpg" (preferred)
- *   - legacy absolute URLs (returned as-is)
+ *   - legacy absolute URLs (returned as-is — Storage transforms only
+ *     work on paths in our private bucket, not on public/external URLs)
  *   - null/empty (returned as null)
  *
- * Caches signed URLs until 5 minutes before expiry to avoid round-trips.
+ * Pass `transform` to request a CDN-resized variant for thumbnails /
+ * avatars instead of the full-size source (audit fix #36-17).
+ *
+ * Caches signed URLs (per path + transform combo) until 5 minutes before
+ * expiry to avoid round-trips.
  */
 export async function resolveMediaUrl(
-  pathOrUrl: string | null | undefined
+  pathOrUrl: string | null | undefined,
+  transform?: MediaTransform
 ): Promise<string | null> {
   if (!pathOrUrl) return null;
+  // Absolute URLs (https://, data:, blob:) include Tenor/Giphy GIFs,
+  // legacy public URLs from before #18, and local previews. Pass them
+  // through unchanged — we can't apply Storage transforms to them.
   if (isAbsoluteUrl(pathOrUrl)) return pathOrUrl;
 
-  const cached = signedUrlCache.get(pathOrUrl);
+  const key = cacheKey(pathOrUrl, transform);
+
+  const cached = signedUrlCache.get(key);
   if (cached && cached.expiresAt - Date.now() > SIGNED_URL_REFRESH_MARGIN_MS) {
     return cached.url;
   }
 
-  // Coalesce concurrent requests for the same path.
-  const inflight = inflightSigning.get(pathOrUrl);
+  // Coalesce concurrent requests for the same path+transform.
+  const inflight = inflightSigning.get(key);
   if (inflight) return inflight;
 
   const promise = (async () => {
-    const { url, error } = await getSignedUrl(pathOrUrl, SIGNED_URL_TTL_SECONDS);
+    const { url, error } = await getSignedUrl(
+      pathOrUrl,
+      SIGNED_URL_TTL_SECONDS,
+      transform
+    );
     if (error || !url) {
       return null;
     }
-    signedUrlCache.set(pathOrUrl, {
+    signedUrlCache.set(key, {
       url,
       expiresAt: Date.now() + SIGNED_URL_TTL_SECONDS * 1000,
     });
     return url;
   })();
 
-  inflightSigning.set(pathOrUrl, promise);
+  inflightSigning.set(key, promise);
   try {
     return await promise;
   } finally {
-    inflightSigning.delete(pathOrUrl);
+    inflightSigning.delete(key);
   }
+}
+
+/**
+ * Synchronously read a cached signed URL (only fresh, non-expiring entries).
+ * Used by useSignedMediaUrl to avoid render-flicker — if we already have a
+ * valid signed URL for this path, return it immediately and skip the
+ * loading state on rerender (audit fix #36-18).
+ */
+export function getCachedMediaUrl(
+  pathOrUrl: string | null | undefined,
+  transform?: MediaTransform
+): string | null {
+  if (!pathOrUrl) return null;
+  if (isAbsoluteUrl(pathOrUrl)) return pathOrUrl;
+
+  const cached = signedUrlCache.get(cacheKey(pathOrUrl, transform));
+  if (cached && cached.expiresAt - Date.now() > SIGNED_URL_REFRESH_MARGIN_MS) {
+    return cached.url;
+  }
+  return null;
 }
 
 /**

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -488,6 +488,14 @@ serve(async (req) => {
           },
           android: {
             priority: 'high',
+            // Issue #32: explicit channel_id ensures heads-up banner with
+            // text preview on Android. Channel is created with
+            // IMPORTANCE_HIGH in ZemichatMessagingService.onCreate().
+            notification: {
+              channel_id: 'messages_v2',
+              default_sound: true,
+              default_vibrate_timings: true,
+            },
           },
           // APNs payload for iOS — FCM proxies this to Apple Push Notification service
           ...(tokenRow.platform === 'ios' ? {

--- a/supabase/migrations/20260502120000_reactions_one_per_user_per_message.sql
+++ b/supabase/migrations/20260502120000_reactions_one_per_user_per_message.sql
@@ -1,0 +1,47 @@
+-- Issue #34: Reactions — max one emoji per user per message (overwrite on new)
+--
+-- Behaviour: WhatsApp/iMessage style. When a user picks a new emoji on a
+-- message, it replaces the old one rather than being added alongside it.
+--
+-- This migration:
+--   1. Cleans up any existing duplicate reactions (keeping the most recent
+--      reaction per (message_id, user_id) pair).
+--   2. Drops the old unique constraint on (message_id, user_id, emoji)
+--      from the initial schema.
+--   3. Adds a new unique constraint on (message_id, user_id) so the database
+--      enforces the one-reaction-per-user invariant.
+--
+-- The migration is idempotent — re-running it on a database that already has
+-- the new constraint is a no-op.
+
+-- 1. De-duplicate: keep the latest reaction per (message_id, user_id).
+--    Older duplicates are removed before we tighten the constraint.
+DELETE FROM public.message_reactions
+WHERE id NOT IN (
+  SELECT DISTINCT ON (message_id, user_id) id
+  FROM public.message_reactions
+  ORDER BY message_id, user_id, created_at DESC
+);
+
+-- 2. Drop the old constraint on (message_id, user_id, emoji) if present.
+--    The default name PostgreSQL assigned to the inline UNIQUE in
+--    20260205090232_initial_schema.sql is
+--    `message_reactions_message_id_user_id_emoji_key`.
+ALTER TABLE public.message_reactions
+  DROP CONSTRAINT IF EXISTS message_reactions_message_id_user_id_emoji_key;
+
+-- 3. Add the new (message_id, user_id) unique constraint, but only if it
+--    is not already present (idempotent).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'message_reactions_one_per_user'
+      AND conrelid = 'public.message_reactions'::regclass
+  ) THEN
+    ALTER TABLE public.message_reactions
+      ADD CONSTRAINT message_reactions_one_per_user
+      UNIQUE (message_id, user_id);
+  END IF;
+END $$;


### PR DESCRIPTION
## v1.5.13 batch

Erik testade v1.5.12 och rapporterade fyra buggar via Telegram. Plus prestanda-audit (issue #36) gav 24 fynd. Den här PR:n implementerar alla rapporterade buggar och TOP 3 av perf-fynden.

## Vad ingår

### Buggar (rapporterade av Erik/Victor)
- #32 Push-notiser kommer inte fram + saknar banner-förhandsgranskning på Android
- #33 Reply-preview citerad text wrappar inte (klips vid bubblans högerkant)
- #34 Reactions: max en emoji per användare per meddelande (overwrite vid ny)
- #35 Emoji-picker-ikon bredvid input inte tryckbar på iOS

### Performance (TOP 3 av 24 fynd från audit #36)
- #36-5 Memo Auth/Notification/Theme/Subscription/Call context-värden — stoppar tree-wide invalidation vid varje state-tick
- #36-8 Sluta extra-SELECT på sender vid varje realtime-event — sparar 200-500 ms per inkommande meddelande
- #36-17 Lazy-loada bilder + Supabase Storage transforms — slutar leverera 3-4 MB original i 200×200-thumb-rutor

## Senarelagt

- #36-1 Virtuoso (chat-listan + meddelandelistan) — M-insats, kräver nytt dependency. v1.5.14.
- #36-7 chat last messages RPC — M-insats, kräver migration. v1.5.14.

## Migrationer

-  — ändrar message_reactions unique-constraint till (message_id, user_id), de-dupliciterar existerande dubbel-reactions först.

## Test plan

- [ ] Erik verifierar push-notiser + heads-up banner på Android telefon (kräver att han avinstallerar och installerar om för att få nya channel messages_v2, channels är immutable)
- [ ] Reply-preview citat radbryter och clamp:as till 3 rader
- [ ] Klicka emoji-icon i chat-input fungerar både Android + iOS (Victor)
- [ ] Reactions: lägg till en, byt till annan, samma användare har bara en
- [ ] Type-check: `npx tsc --noEmit` passerar (verifierat: EXIT=0)
- [ ] Cold start på 4G känns snabbare (perf-fixarna)

## Build-impact

- versionCode 30 → 31, versionName 1.5.12 → 1.5.13
- AAB + IPA byggs av Codemagic vid merge
- send-push edge function måste re-deployas separat efter merge (`supabase functions deploy send-push --project-ref qrrorlxocpxvqcfdipbq`)

🤖 Genererat med [Claude Code](https://claude.com/claude-code)