### PR TITLE
fix(v1.5.14): batch — virtuoso #36-1 + chat RPC #36-7

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.zemichat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 31
-        versionName "1.5.13"
+        versionCode 32
+        versionName "1.5.14"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
             debugSymbolLevel 'FULL'

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
         "react-i18next": "^16.5.4",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
-        "react-swipeable": "^7.0.2"
+        "react-swipeable": "^7.0.2",
+        "react-virtuoso": "^4.18.6"
       },
       "devDependencies": {
         "@capacitor/assets": "^3.0.5",
@@ -14133,6 +14134,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.6",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.6.tgz",
+      "integrity": "sha512-CrT3P6HyjJMHZVWSste2bG2q5aWGlHfW2QuySZjiFwB2Qok/xsvgy+k8Z2jeDP8PP5KsBip7zNrl/F0QoxeyKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/read-cmd-shim": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "react-i18next": "^16.5.4",
     "react-router": "^5.3.4",
     "react-router-dom": "^5.3.4",
-    "react-swipeable": "^7.0.2"
+    "react-swipeable": "^7.0.2",
+    "react-virtuoso": "^4.18.6"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",

--- a/src/pages/ChatView.tsx
+++ b/src/pages/ChatView.tsx
@@ -14,6 +14,7 @@ import {
   IonButton,
   IonToast,
 } from '@ionic/react';
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { searchOutline, arrowDown } from 'ionicons/icons';
 import { Keyboard } from '@capacitor/keyboard';
 import { Capacitor } from '@capacitor/core';
@@ -101,6 +102,10 @@ const ChatView: React.FC = () => {
   const contentRef = useRef<HTMLIonContentElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const mediaPickerRef = useRef<MediaPickerHandle>(null);
+  // Virtuoso replaces IonContent's native scroll for the message list — see
+  // <Virtuoso /> render below. Audit fix #21 (onIonScroll throttling) is
+  // moot once Virtuoso owns the scroll surface.
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
 
   // Reply state
   const [replyTo, setReplyTo] = useState<MessageWithSender | null>(null);
@@ -191,36 +196,25 @@ const ChatView: React.FC = () => {
   }, []);
 
   // --- Scroll detection ---
-  const handleScroll = useCallback(async () => {
-    const el = contentRef.current;
-    if (!el) return;
-
-    const scrollEl = await el.getScrollElement();
-    const { scrollTop, scrollHeight, clientHeight } = scrollEl;
-    const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
-    const nearBottom = distanceFromBottom < 200;
-    setIsNearBottom(nearBottom);
-    isNearBottomRef.current = nearBottom;
-
-    if (nearBottom) {
+  // Virtuoso owns the scroll surface for the message list, so we no longer
+  // listen to ionScroll for the messages container. atBottomStateChange below
+  // keeps isNearBottomRef + newMessageCount in sync. The old onIonScroll
+  // throttle concern (audit fix #21) is therefore no longer relevant.
+  const handleAtBottomStateChange = useCallback((atBottom: boolean) => {
+    setIsNearBottom(atBottom);
+    isNearBottomRef.current = atBottom;
+    if (atBottom) {
       setNewMessageCount(0);
     }
   }, []);
 
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
-
-    el.addEventListener('ionScroll', handleScroll);
-    return () => {
-      el.removeEventListener('ionScroll', handleScroll);
-    };
-  }, [handleScroll]);
-
   const scrollToBottom = useCallback(() => {
-    setTimeout(() => {
-      contentRef.current?.scrollToBottom(300);
-    }, 100);
+    // Virtuoso schedules the scroll itself; no need for a setTimeout dance.
+    virtuosoRef.current?.scrollToIndex({
+      index: 'LAST',
+      behavior: 'smooth',
+      align: 'end',
+    });
   }, []);
 
   const scrollToBottomRef = useRef(scrollToBottom);
@@ -319,28 +313,18 @@ const ChatView: React.FC = () => {
           return [...prev, newMessage];
         });
 
-        // Mät scroll-position FÄRSKT istället för cached ref. När användaren
-        // skriver i textarea triggas ingen scroll-event, så cached ref kan
-        // vara stale och nya meddelanden scrollas inte fram.
-        const computeNearBottom = async (): Promise<boolean> => {
-          const el = contentRef.current;
-          if (!el) return true;
-          const scrollEl = await el.getScrollElement();
-          const dist = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight;
-          return dist < 500;
-        };
-
-        computeNearBottom().then((near) => {
-          isNearBottomRef.current = near;
-          if (near) {
-            scrollToBottomRef.current();
-            if (newMessage.sender_id !== profile?.id) {
-              insertReadReceipts([newMessage.id]);
-            }
-          } else {
-            setNewMessageCount((n) => n + 1);
+        // Virtuoso håller isNearBottomRef färsk via atBottomStateChange;
+        // followOutput="smooth" sköter själva auto-scroll-animationen för
+        // nya meddelanden när vi redan är vid botten. Vi kompletterar bara
+        // med read-receipt + newMessageCount-räkning.
+        const near = isNearBottomRef.current;
+        if (near) {
+          if (newMessage.sender_id !== profile?.id) {
+            insertReadReceipts([newMessage.id]);
           }
-        });
+        } else {
+          setNewMessageCount((n) => n + 1);
+        }
 
         loadReactionsRef.current([newMessage.id]);
 
@@ -515,16 +499,20 @@ const ChatView: React.FC = () => {
   };
 
   const handleJumpToMessage = useCallback((messageId: string) => {
-    const el = document.querySelector(
-      `[data-message-id="${messageId}"]`
-    ) as HTMLElement | null;
-    if (!el) return;
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Virtualized list: bubbla kan vara ur DOM. Hitta index och be Virtuoso
+    // scrolla — den materialiserar item-noden själv.
+    const idx = messages.findIndex((m) => m.id === messageId);
+    if (idx === -1) return;
+    virtuosoRef.current?.scrollToIndex({
+      index: idx,
+      behavior: 'smooth',
+      align: 'center',
+    });
     setHighlightedMessageId(messageId);
     setTimeout(() => {
       setHighlightedMessageId((prev) => (prev === messageId ? null : prev));
     }, 1700);
-  }, []);
+  }, [messages]);
 
   const handleContextMenu = (message: MessageWithSender, _rect: DOMRect) => {
     setContextMenuTarget(message);
@@ -811,8 +799,6 @@ const ChatView: React.FC = () => {
         ref={contentRef}
         className="chat-content"
         fullscreen
-        scrollEvents
-        onIonScroll={handleScroll}
       >
         {isLoading ? (
           <SkeletonLoader variant="messages" />
@@ -827,45 +813,72 @@ const ChatView: React.FC = () => {
             className="messages-container"
             data-testid="messages-container"
           >
-            {(() => {
-              const galleryUrls = getGalleryUrls(messages);
-              return messages.map((message, index) => {
-              const isOwn = message.sender_id === profile?.id;
-              const showDivider = shouldShowDateDivider(message, index);
-              const messageReactions = reactions.get(message.id) || [];
+            <Virtuoso
+              ref={virtuosoRef}
+              style={{ height: '100%' }}
+              data={messages}
+              totalCount={messages.length}
+              initialTopMostItemIndex={messages.length - 1}
+              followOutput="smooth"
+              atBottomStateChange={handleAtBottomStateChange}
+              atBottomThreshold={200}
+              rangeChanged={({ startIndex, endIndex }) => {
+                // Mark visible inbound messages as read. Cheap no-op when
+                // already read (insertReadReceipts dedupes server-side).
+                const ids: string[] = [];
+                for (let i = startIndex; i <= endIndex; i++) {
+                  const m = messages[i];
+                  if (m && m.sender_id !== profile?.id) {
+                    ids.push(m.id);
+                  }
+                }
+                if (ids.length > 0) {
+                  insertReadReceipts(ids);
+                }
+              }}
+              components={{
+                Footer: () => (
+                  <TypingIndicator typers={typers} isGroup={chat?.is_group} />
+                ),
+              }}
+              itemContent={(index, message) => {
+                const isOwn = message.sender_id === profile?.id;
+                const showDivider = shouldShowDateDivider(message, index);
+                const messageReactions = reactions.get(message.id) || [];
+                const galleryUrls = getGalleryUrls(messages);
 
-              return (
-                <div key={message.id}>
-                  {showDivider && (
-                    <div className="date-divider">
-                      <span>{formatDateDivider(message.created_at)}</span>
+                return (
+                  <>
+                    {showDivider && (
+                      <div className="date-divider">
+                        <span>{formatDateDivider(message.created_at)}</span>
+                      </div>
+                    )}
+                    <div
+                      className={`message-wrapper ${isOwn ? 'own' : 'other'}`}
+                      data-testid={`message-${message.id}`}
+                    >
+                      <MessageBubble
+                        message={message}
+                        isOwn={isOwn}
+                        reactions={messageReactions}
+                        showSenderName={chat?.is_group && !isOwn}
+                        readStatus={getReadStatus(message)}
+                        isJustSent={message.id === lastSentId}
+                        galleryUrls={galleryUrls}
+                        onReply={() => handleReply(message)}
+                        onContextMenu={(msg, rect) => handleContextMenu(msg, rect)}
+                        onJumpToMessage={handleJumpToMessage}
+                        userId={profile?.id}
+                        userRole={profile?.role}
+                        onToggleReaction={handleToggleReaction}
+                        isHighlighted={highlightedMessageId === message.id}
+                      />
                     </div>
-                  )}
-                  <div className={`message-wrapper ${isOwn ? 'own' : 'other'}`} data-testid={`message-${message.id}`}>
-                    <MessageBubble
-                      message={message}
-                      isOwn={isOwn}
-                      reactions={messageReactions}
-                      showSenderName={chat?.is_group && !isOwn}
-                      readStatus={getReadStatus(message)}
-                      isJustSent={message.id === lastSentId}
-                      galleryUrls={galleryUrls}
-                      onReply={() => handleReply(message)}
-                      onContextMenu={(msg, rect) => handleContextMenu(msg, rect)}
-                      onJumpToMessage={handleJumpToMessage}
-                      userId={profile?.id}
-                      userRole={profile?.role}
-                      onToggleReaction={handleToggleReaction}
-                      isHighlighted={highlightedMessageId === message.id}
-                    />
-                  </div>
-                </div>
-              );
-            });
-            })()}
-
-            {/* Typing indicator */}
-            <TypingIndicator typers={typers} isGroup={chat?.is_group} />
+                  </>
+                );
+              }}
+            />
           </div>
         )}
 
@@ -934,6 +947,8 @@ const ChatView: React.FC = () => {
             display: flex;
             flex-direction: column;
             padding: 1rem;
+            /* Virtuoso behöver en explicit höjd; .chat-content fyller IonContent. */
+            height: 100%;
             min-height: 100%;
           }
 
@@ -941,8 +956,9 @@ const ChatView: React.FC = () => {
             display: flex;
             justify-content: center;
             margin: 1rem 0;
-            position: sticky;
-            top: 0;
+            /* position: sticky funkar inte i en virtualiserad lista där noder
+               unmountas — divider:n renderas inline ovanför första meddelandet
+               för respektive datum istället. */
             z-index: 10;
           }
 

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -22,134 +22,70 @@ export interface CreateChatResult {
   error: Error | null;
 }
 
-// Helper types for Supabase query results
-interface ChatMemberWithChat {
-  chat_id: string;
+interface ChatMemberWithUser extends ChatMember {
+  user: User;
+}
+
+// Shape returned by the get_my_chats_with_last_message RPC. One row per chat
+// where the caller is an active member, with members + last message bundled
+// as JSON so the whole chat list arrives in a single round-trip.
+interface MyChatsRpcRow {
+  id: string;
+  name: string | null;
+  description: string | null;
+  avatar_url: string | null;
+  is_group: boolean;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
   unread_count: number;
   is_pinned: boolean;
   is_archived: boolean;
   is_muted: boolean;
   marked_unread: boolean;
-  chats: Chat;
-}
-
-interface ChatMemberWithUser extends ChatMember {
-  user: User;
+  members: ChatMemberWithUser[] | null;
+  last_message: Message | null;
 }
 
 /**
  * Get all chats for the current user with member details and last message.
+ *
+ * Uses a single SECURITY DEFINER RPC (get_my_chats_with_last_message) that
+ * returns one row per chat, including aggregated members and the most recent
+ * non-deleted message via LATERAL LIMIT 1. This replaces the previous flow
+ * that issued three queries and pulled every message in every chat with no
+ * limit (audit fix #36-7).
  */
 export async function getMyChats(): Promise<{ chats: ChatWithDetails[]; error: Error | null }> {
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return { chats: [], error: new Error('Not authenticated') };
+    const { data, error } = await supabase.rpc('get_my_chats_with_last_message' as never);
+
+    if (error) {
+      return { chats: [], error: new Error((error as { message: string }).message) };
     }
 
-    // Get chat IDs where current user is a member
-    const { data: memberData, error: memberError } = await supabase
-      .from('chat_members')
-      .select(`
-        chat_id,
-        unread_count,
-        is_pinned,
-        is_archived,
-        is_muted,
-        marked_unread,
-        chats (
-          id,
-          name,
-          description,
-          avatar_url,
-          is_group,
-          created_by,
-          created_at,
-          updated_at
-        )
-      `)
-      .eq('user_id', user.id)
-      .is('left_at', null)
-      .order('is_pinned', { ascending: false });
+    const rows = (data || []) as unknown as MyChatsRpcRow[];
 
-    if (memberError) {
-      return { chats: [], error: new Error(memberError.message) };
-    }
+    const chats: ChatWithDetails[] = rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      avatar_url: row.avatar_url,
+      is_group: row.is_group,
+      created_by: row.created_by,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      members: row.members ?? [],
+      lastMessage: row.last_message ?? undefined,
+      unreadCount: row.unread_count,
+      isPinned: row.is_pinned,
+      isArchived: row.is_archived,
+      isMuted: row.is_muted,
+      markedUnread: row.marked_unread,
+    }));
 
-    if (!memberData || memberData.length === 0) {
-      return { chats: [], error: null };
-    }
-
-    const typedMemberData = memberData as unknown as ChatMemberWithChat[];
-    const chatIds = typedMemberData.map((m) => m.chat_id);
-
-    // Get all members for these chats with user details
-    const { data: allMembers, error: allMembersError } = await supabase
-      .from('chat_members')
-      .select(`
-        *,
-        user:users (*)
-      `)
-      .in('chat_id', chatIds)
-      .is('left_at', null);
-
-    if (allMembersError) {
-      return { chats: [], error: new Error(allMembersError.message) };
-    }
-
-    // Get last message for each chat
-    const { data: lastMessages, error: lastMessagesError } = await supabase
-      .from('messages')
-      .select('*')
-      .in('chat_id', chatIds)
-      .is('deleted_at', null)
-      .order('created_at', { ascending: false });
-
-    if (lastMessagesError) {
-      console.error('Failed to get last messages:', lastMessagesError);
-    }
-
-    const typedMembers = (allMembers || []) as unknown as ChatMemberWithUser[];
-    const typedMessages = (lastMessages || []) as unknown as Message[];
-
-    // Group members by chat
-    const membersByChat = new Map<string, ChatMemberWithUser[]>();
-    for (const member of typedMembers) {
-      const chatMembers = membersByChat.get(member.chat_id) || [];
-      chatMembers.push(member);
-      membersByChat.set(member.chat_id, chatMembers);
-    }
-
-    // Get last message per chat
-    const lastMessageByChat = new Map<string, Message>();
-    for (const msg of typedMessages) {
-      if (!lastMessageByChat.has(msg.chat_id)) {
-        lastMessageByChat.set(msg.chat_id, msg);
-      }
-    }
-
-    // Build chat list with details
-    const chats: ChatWithDetails[] = typedMemberData.map((m) => {
-      const chat = m.chats;
-      return {
-        ...chat,
-        members: membersByChat.get(m.chat_id) || [],
-        lastMessage: lastMessageByChat.get(m.chat_id),
-        unreadCount: m.unread_count,
-        isPinned: m.is_pinned,
-        isArchived: m.is_archived,
-        isMuted: m.is_muted,
-        markedUnread: m.marked_unread,
-      };
-    });
-
-    // Sort by last message time (most recent first)
-    chats.sort((a, b) => {
-      const aTime = a.lastMessage?.created_at || a.created_at;
-      const bTime = b.lastMessage?.created_at || b.created_at;
-      return new Date(bTime).getTime() - new Date(aTime).getTime();
-    });
-
+    // The RPC orders by is_pinned DESC, then last_message/chat created_at DESC.
+    // Re-sorting in JS would be redundant; trust the server.
     return { chats, error: null };
   } catch (err) {
     return {

--- a/supabase/migrations/20260504070000_chats_with_last_message_rpc.sql
+++ b/supabase/migrations/20260504070000_chats_with_last_message_rpc.sql
@@ -1,0 +1,143 @@
+-- Audit fix #36-7: eliminate the N+1 / unbounded fetch in services/chat.ts
+-- getMyChats. The old client flow ran:
+--   1) chat_members (mine) join chats
+--   2) chat_members (all) join users for those chats
+--   3) messages SELECT * for ALL chats with no LIMIT — pulling thousands of
+--      rows just to take the most recent per chat on the client.
+--
+-- This RPC returns one row per chat in which the caller is an active member
+-- (left_at IS NULL), bundling:
+--   - the chat row
+--   - the caller's chat_members fields (unread_count, is_pinned, ...)
+--   - all active members joined with their users row, as a JSON array
+--   - the chat's most recent non-deleted message, via LATERAL LIMIT 1, as JSON
+--
+-- SECURITY DEFINER so it can bypass RLS recursion on chat_members; the body
+-- gates on auth.uid() and only ever returns chats the caller is a member of.
+
+CREATE OR REPLACE FUNCTION get_my_chats_with_last_message()
+RETURNS TABLE (
+  -- chats columns
+  id           uuid,
+  name         text,
+  description  text,
+  avatar_url   text,
+  is_group     boolean,
+  created_by   uuid,
+  created_at   timestamptz,
+  updated_at   timestamptz,
+  -- caller's chat_members fields
+  unread_count int,
+  is_pinned    boolean,
+  is_archived  boolean,
+  is_muted     boolean,
+  marked_unread boolean,
+  -- aggregated members + last message
+  members      jsonb,
+  last_message jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    c.id,
+    c.name,
+    c.description,
+    c.avatar_url,
+    c.is_group,
+    c.created_by,
+    c.created_at,
+    c.updated_at,
+    my_cm.unread_count,
+    my_cm.is_pinned,
+    my_cm.is_archived,
+    my_cm.is_muted,
+    my_cm.marked_unread,
+    -- All active members of the chat, with their user record nested as `user`.
+    -- Aggregated into a JSON array so the client gets one round-trip.
+    COALESCE(
+      (
+        SELECT jsonb_agg(
+                 jsonb_build_object(
+                   'id',           cm.id,
+                   'chat_id',      cm.chat_id,
+                   'user_id',      cm.user_id,
+                   'joined_at',    cm.joined_at,
+                   'left_at',      cm.left_at,
+                   'is_muted',     cm.is_muted,
+                   'is_pinned',    cm.is_pinned,
+                   'is_archived',  cm.is_archived,
+                   'unread_count', cm.unread_count,
+                   'last_read_at', cm.last_read_at,
+                   'marked_unread', cm.marked_unread,
+                   'muted_until',  cm.muted_until,
+                   'user', jsonb_build_object(
+                     'id',             u.id,
+                     'team_id',        u.team_id,
+                     'role',           u.role,
+                     'zemi_number',    u.zemi_number,
+                     'display_name',   u.display_name,
+                     'avatar_url',     u.avatar_url,
+                     'status_message', u.status_message,
+                     'last_seen_at',   u.last_seen_at,
+                     'is_active',      u.is_active,
+                     'is_paused',      u.is_paused,
+                     'wall_enabled',   u.wall_enabled,
+                     'consent_accepted_at', u.consent_accepted_at,
+                     'created_at',     u.created_at,
+                     'updated_at',     u.updated_at
+                   )
+                 )
+               )
+        FROM chat_members cm
+        JOIN users u ON u.id = cm.user_id
+        WHERE cm.chat_id = c.id AND cm.left_at IS NULL
+      ),
+      '[]'::jsonb
+    ) AS members,
+    -- Most recent non-deleted message in the chat (or NULL if none).
+    -- Uses idx_messages_created (chat_id, created_at DESC) for an O(log n)
+    -- index lookup per chat instead of scanning all rows.
+    to_jsonb(lm) AS last_message
+  FROM chat_members my_cm
+  JOIN chats c ON c.id = my_cm.chat_id
+  LEFT JOIN LATERAL (
+    SELECT m.id,
+           m.chat_id,
+           m.sender_id,
+           m.type,
+           m.content,
+           m.media_url,
+           m.media_metadata,
+           m.reply_to_id,
+           m.forwarded_from_id,
+           m.contact_zemi_number,
+           m.is_edited,
+           m.edited_at,
+           m.deleted_at,
+           m.deleted_by,
+           m.deleted_for_all,
+           m.created_at
+    FROM messages m
+    WHERE m.chat_id = c.id
+      AND m.deleted_at IS NULL
+    ORDER BY m.created_at DESC
+    LIMIT 1
+  ) lm ON true
+  WHERE my_cm.user_id = v_uid
+    AND my_cm.left_at IS NULL
+  ORDER BY my_cm.is_pinned DESC,
+           COALESCE(lm.created_at, c.created_at) DESC;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_my_chats_with_last_message() TO authenticated;


### PR DESCRIPTION
## v1.5.14 batch — TOP 2 perf-fynden från audit #36

Implementerar de två sista perf-fynden från audit #36 som senarelagts från v1.5.13.

## Vad ingår

### #36-1 react-virtuoso virtualisering av meddelandelistan
- Adderar dep react-virtuoso ^4.18.6
- ChatView.tsx: messages.map() ersatts med Virtuoso. followOutput=smooth, scrollToIndex för reply-jumps, rangeChanged för read-receipt visibility-tracking
- Date dividers renderas inline i itemContent (sticky CSS borttagen)
- IonContent onIonScroll-handler borttagen — virtuoso äger scroll

### #36-7 chat last-message RPC
- Migration 20260504070000_chats_with_last_message_rpc.sql skapar SECURITY DEFINER-funktion get_my_chats_with_last_message()
- chat.ts:getMyChats() collapsar från 3 sequential queries (~60 rader) till en supabase.rpc-call
- LEFT JOIN LATERAL + LIMIT 1 per chat istället för wide messages SELECT
- Return-shape oförändrat → ChatList.tsx orörd

## Build-impact

- versionCode 31 → 32, versionName 1.5.13 → 1.5.14
- DB-migration MÅSTE deployas innan AAB-bygget — annars 404 från RPC i klienten

## Test plan

PDF-checklista som täcker v1.5.12 → v1.5.14:
https://docs.google.com/document/d/1sH3ay8k4RdXj9IdKkePSpJg_P9F3UeTZy5aH95oA0NU/edit

Erik och Matilda kör manuell verifiering med rutor att kryssa i.

🤖 Genererat med [Claude Code](https://claude.com/claude-code)