### PR TITLE
docs(claude): require docs updates per batch + ADR template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,22 @@ Efter VARJE korrigering från Erik:
 - Skriv en regel som förhindrar samma misstag
 - Läs lessons vid sessionens start för relevanta projekt
 
+### 4. Uppdatera styrande dokument vid varje batch
+Innan en PR mergas, varje batch som introducerar nya funktioner, schemaändringar eller arkitektoniska val MÅSTE inkludera:
+
+- **`docs/PRD.md`** uppdaterad om feature-beteendet ändras eller en ny feature läggs till. Skriv vad användaren ska kunna göra, vilka roller som påverkas, och hur det interagerar med transparens-modellen.
+- **`docs/SCHEMA.md`** uppdaterad om schemat ändras (nya tabeller, kolumner, index, FK-policies). Inkludera ON DELETE-strategi för varje FK.
+- **`docs/RLS.md`** uppdaterad om policies tillkommer eller ändras.
+- **`docs/decisions/YYYY-MM-DD-N-titel.md`** skapas för icke-triviala arkitektoniska val. Format: vad valdes, vilka alternativ förkastades, varför. Format-mall finns i `docs/decisions/_template.md`.
+
+Detta är inte valfritt. Det är en gate i PR-flödet:
+
+> *"Vibe coding without architecture isn't building. It's accumulating debt."*
+
+PR utan motsvarande doc-uppdateringar (när ändringarna kräver det) får inte mergas. Reviewer-checklistan ska explicit kolla doc-uppdateringen.
+
+**Undantag som inte kräver doc-uppdatering:** rena buggfixar inom befintligt feature-scope, prestanda-optimeringar utan API-ändring, dependency-bumps, refactors utan beteendeförändring. Vid tveksamhet — uppdatera dokumentet.
+
 ---
 
 ## Utvecklingsprinciper
@@ -383,4 +399,4 @@ Om beslutet påverkar:
 
 ---
 
-*Senast uppdaterad: 2025-02-20*
+*Senast uppdaterad: 2026-05-07*

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,0 +1,57 @@
+# YYYY-MM-DD-N: Titel på beslutet
+
+*Architecture Decision Record (ADR). Kopiera denna fil och fyll i.*
+
+## Status
+
+`Föreslagen` | `Accepterad` | `Förkastad` | `Ersatt av YYYY-MM-DD-M`
+
+## Kontext
+
+Vad fick oss att överväga det här valet? Vilket problem är vi att lösa, vilket tekniskt val står vi inför, vilka constraints (tid, budget, kompetens, befintlig stack) finns?
+
+## Övervägda alternativ
+
+### Alt 1: <namn>
+
+- För:
+- Mot:
+- Insats:
+
+### Alt 2: <namn>
+
+- För:
+- Mot:
+- Insats:
+
+### Alt 3: <namn>
+
+- För:
+- Mot:
+- Insats:
+
+## Beslut
+
+Vilket alternativ valdes och varför.
+
+## Konsekvenser
+
+### Positiva
+
+-
+
+### Negativa / risker
+
+-
+
+### Vad som är inlåst
+
+Vad blir svårt att ändra senare? När bör vi omvärdera detta beslut (t.ex. om antalet användare överstiger X, eller om Z-tekniken blir tillgänglig)?
+
+## Implementation
+
+Vilka filer/moduler påverkas? Länk till PR där implementationen finns.
+
+## Referenser
+
+- Externa länkar, RFC:er, dokumentation


### PR DESCRIPTION
## Process-uppdatering — inte buggfix

Lägger till regel 4 i CLAUDE.md som tvingar oss att hålla styrande dokument synkade med kodbasen vid varje batch.

## Bakgrund

Erik delade en LinkedIn-post idag (Jacob Klug, Creme Digital) om en viral Reddit-tråd: "vibe coded for 6 months. my codebase is a disaster." Mönstret: AI bygger snabbare än arkitekturen ska struktureras, debt staplas tyst, repo blir orört efter månader.

Vi är inte i det extrema läget — vi har PRD, SCHEMA, RLS-docs, regelbundna audits. **Men** vi har ärlig debt:
- Audit #36 hittade 24 fynd
- Issue #41 (11 FK utan CASCADE) visar att delete-flödet aldrig arkitekturlades
- SOS-banner-globaliseringen, invite-link-localhost, send-mail-fel — alla **config/arkitektur-glipor**, inte buggar i koden

## Vad regeln säger

Vid varje batch som introducerar nya funktioner / schemaändringar / arkitekturella val MÅSTE PR:n inkludera:
-  uppdaterad om feature ändrar beteende
-  uppdaterad om schema ändras (inkl. ON DELETE-strategi för FK)
-  uppdaterad om policies ändras
-  skapas för icke-triviala val

Ej valfritt. Reviewer-checklistan tvingar.

**Undantag:** rena buggfixar, prestanda-optimeringar utan API-ändring, dep-bumps, beteende-preservande refactors.

## Vad som ingår

- CLAUDE.md får regel 4 "Uppdatera styrande dokument vid varje batch"
-  — ADR-mall för Architecture Decision Records

## Påverkan

Från och med nästa batch (v1.5.15): varje icke-trivial PR ska peka på doc-uppdateringar. Det är en disciplin-gate, inte en kod-ändring.

🤖 Genererat med [Claude Code](https://claude.com/claude-code)