### PR TITLE
v1.5.15 - #39 + #41

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.zemichat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 32
-        versionName "1.5.14"
+        versionCode 33
+        versionName "1.5.15"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
             debugSymbolLevel 'FULL'

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.zemichat.app',
   appName: 'Zemichat',
-  version: '1.3.1',
+  version: '1.5.15',
   webDir: 'dist',
   android: {
     buildOptions: {

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -18,6 +18,7 @@ workflows:
         XCODE_SCHEME: "App"
         APP_STORE_CONNECT_APP_ID: "6758961616"
         BUNDLE_ID: "com.zemichat.app"
+        VITE_APP_URL: "https://app.zemichat.com"
         VITE_SUPABASE_URL: "https://qrrorlxocpxvqcfdipbq.supabase.co"
         VITE_SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFycm9ybHhvY3B4dnFjZmRpcGJxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzAyODA3ODIsImV4cCI6MjA4NTg1Njc4Mn0.t7wtlKhS34SVX0Jw0d9kI36PaEK_OdhG4mU0XIh7ocU"
         VITE_REVENUECAT_IOS_KEY: "appl_BMmHxKRyBZvHYClLGUzqyDFeARS"
@@ -162,6 +163,7 @@ workflows:
         - zemichat_keystore
       vars:
         PACKAGE_NAME: "com.zemichat.app"
+        VITE_APP_URL: "https://app.zemichat.com"
         VITE_SUPABASE_URL: "https://qrrorlxocpxvqcfdipbq.supabase.co"
         VITE_SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFycm9ybHhvY3B4dnFjZmRpcGJxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzAyODA3ODIsImV4cCI6MjA4NTg1Njc4Mn0.t7wtlKhS34SVX0Jw0d9kI36PaEK_OdhG4mU0XIh7ocU"
         VITE_REVENUECAT_IOS_KEY: "appl_BMmHxKRyBZvHYClLGUzqyDFeARS"

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -718,6 +718,36 @@ Se separat dokument: [RLS.md](./RLS.md)
 
 ---
 
+## ON DELETE-policy på FKs mot users/teams/chats
+
+Normaliserad av migration `20260512090000_fk_cascade_user_team_delete.sql`
+(issue #41). Skiljer på två fall: `CASCADE` när barnraden är meningslös
+utan föräldern, `SET NULL` när raden ska överleva men referensen tappas.
+
+| FK                              | Policy     | Motivering                                                              |
+| ------------------------------- | ---------- | ----------------------------------------------------------------------- |
+| `poll_votes.user_id`            | CASCADE    | rösten är per-user                                                       |
+| `polls.creator_id`              | SET NULL   | enkäten består, "skapad av borttagen användare"                          |
+| `message_reactions.user_id`     | CASCADE    | reaktion är per-user                                                     |
+| `message_read_receipts.user_id` | CASCADE    | läskvitto är per-user                                                    |
+| `messages.sender_id`            | SET NULL   | meddelanden bevaras; klienten renderar "Borttagen användare"             |
+| `chat_members.user_id`          | CASCADE    | medlemskap är join-rad, ingen mening utan user                           |
+| `push_tokens.user_id`           | CASCADE    | token är enhet-per-user                                                  |
+| `texter_settings.user_id`       | CASCADE    | inställningar är per-user                                                |
+| `call_logs.chat_id`             | CASCADE    | samtalslog följer chatten                                                |
+| `call_logs.initiator_id`        | SET NULL   | bevara historik när initiator försvinner                                 |
+| `chats.created_by`              | SET NULL   | chatten överlever skaparens borttagning                                  |
+
+Konsekvenser klient-sidan:
+- `messages.sender_id` kan vara `NULL` — rendera "Borttagen användare" i
+  bubblan istället för att krascha.
+- `chats.created_by` kan vara `NULL` — `created_by`-baserade RLS-policies
+  och dashboards måste hantera fallet.
+- `polls.creator_id` och `call_logs.initiator_id` kan vara `NULL` —
+  motsvarande UI ska visa fallback-namn.
+
+---
+
 ## Migrations-ordning
 
 1. `001_create_enums.sql` – Alla enum-typer

--- a/docs/decisions/2026-05-12-1-fk-ondelete-policy.md
+++ b/docs/decisions/2026-05-12-1-fk-ondelete-policy.md
@@ -1,0 +1,108 @@
+# 2026-05-12-1: ON DELETE-policy på FKs mot users/teams/chats
+
+## Status
+
+`Accepterad`
+
+## Kontext
+
+Issue #41: vid försök att radera ett team + dess users via Supabase Admin
+API (`DELETE auth.users`) failar anropet med 11 olika FK-violations
+(SQLSTATE 23503). Resultatet är att alla "radera mitt konto"-flöden i
+klienten kraschar, och vi måste städa manuellt i SQL för varje radering.
+
+Grundorsaken: 11 FKs skapades utan `ON DELETE`-policy, så Postgres
+default `NO ACTION` blockerar parent-DELETE när det finns kvarvarande
+child-rader.
+
+Vi måste välja en konsekvent strategi för **varje** FK: ska child-raden
+försvinna med parent (`CASCADE`) eller överleva med tappad referens
+(`SET NULL`)?
+
+## Övervägda alternativ
+
+### Alt 1: CASCADE överallt
+
+- För: enklast att resonera kring; en DELETE auth.users städar allt.
+- Mot: meddelandehistorik och samtalsloggar försvinner helt när en user
+  raderas. För Owner-transparensmodellen är detta direkt skadligt — en
+  Texter som raderas kunde retroaktivt "rensa" hela sin chatthistorik
+  från Owner's vy.
+- Insats: liten.
+
+### Alt 2: SET NULL överallt
+
+- För: ingen data försvinner, allt blir auditbart.
+- Mot: join-tabeller (chat_members, message_reactions, push_tokens,
+  texter_settings) blir orphaned rader utan mening. push_tokens utan
+  user blir aktivt skadligt — vi skulle skicka push till "ingen".
+- Insats: liten.
+
+### Alt 3: Hybrid per FK (valt)
+
+- För: respekterar respektive radens semantik. Join-tabeller och
+  per-user-state cascades; historik (meddelanden, samtalsloggar,
+  enkäter) bevaras med null-referens.
+- Mot: kräver att klienten hanterar null-referenser i UI (visar
+  "Borttagen användare" i bubblor, etc.). Måste dokumenteras tydligt.
+- Insats: medel — 11 ALTER TABLE plus klient-hardening.
+
+## Beslut
+
+Alt 3 — hybrid per FK. Policy per kolumn:
+
+| FK                              | Policy     |
+| ------------------------------- | ---------- |
+| `poll_votes.user_id`            | CASCADE    |
+| `polls.creator_id`              | SET NULL   |
+| `message_reactions.user_id`     | CASCADE    |
+| `message_read_receipts.user_id` | CASCADE    |
+| `messages.sender_id`            | SET NULL   |
+| `chat_members.user_id`          | CASCADE    |
+| `push_tokens.user_id`           | CASCADE    |
+| `texter_settings.user_id`       | CASCADE    |
+| `call_logs.chat_id`             | CASCADE    |
+| `call_logs.initiator_id`        | SET NULL   |
+| `chats.created_by`              | SET NULL   |
+
+Tre kolumner får dessutom `DROP NOT NULL` så `SET NULL` är legalt:
+`messages.sender_id`, `call_logs.initiator_id`, `chats.created_by`.
+Plus `polls.creator_id` som var `NOT NULL`.
+
+## Konsekvenser
+
+### Positiva
+
+- "Radera mitt konto"-flödet fungerar utan FK-violations.
+- Owner-transparensmodellen bevarad: meddelanden och samtalsloggar
+  försvinner inte när en Texter raderas — bara avsändaren blir null.
+- Per-user-state (notifikations-tokens, läskvitton, reaktioner) städas
+  automatiskt utan kvarvarande spöken.
+
+### Negativa / risker
+
+- Klienten måste rendera `sender = null` korrekt. Idag kraschar
+  sannolikt rendering om sender är null — uppföljs i separat issue
+  innan en faktisk user-deletion körs i prod.
+- RLS-policies som filtrerar på `created_by` eller `sender_id` måste
+  granskas — de måste tåla `IS NULL`.
+- En raderad Owner får sin team-cascade automatiskt (initial schema:
+  `teams.owner_id` ON DELETE CASCADE → users ON DELETE CASCADE). Vi
+  rör inte den policyn här.
+
+### Vad som är inlåst
+
+- Att meddelanden bevaras med null-sender är en transparens-
+  mekanism. Om vi senare beslutar att "radera mitt konto = total
+  GDPR-rensning" måste vi vända till CASCADE — det ändrar produktens
+  trygghetsmodell och kräver explicit produktbeslut.
+
+## Implementation
+
+- `supabase/migrations/20260512090000_fk_cascade_user_team_delete.sql`
+- `docs/SCHEMA.md` — uppdaterad med tabellen över ON DELETE-policy
+- PR: v1.5.15-batch
+
+## Referenser
+
+- Issue #41

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zemichat",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.5.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ShareTargetHandler.tsx
+++ b/src/components/ShareTargetHandler.tsx
@@ -279,7 +279,7 @@ const ShareTargetHandler: React.FC = () => {
                   >
                     <IonAvatar slot="start" className="share-picker-avatar">
                       {avatarUrl ? (
-                        <img src={avatarUrl} alt="" />
+                        <img src={avatarUrl} alt="" loading="lazy" decoding="async" />
                       ) : (
                         <div className="share-avatar-placeholder">{initial}</div>
                       )}

--- a/src/components/call/AddParticipantPicker.tsx
+++ b/src/components/call/AddParticipantPicker.tsx
@@ -84,7 +84,7 @@ const AddParticipantPicker: React.FC<AddParticipantPickerProps> = ({
               >
                 <IonAvatar slot="start">
                   {user.avatar_url ? (
-                    <img src={user.avatar_url} alt={user.display_name || ''} />
+                    <img src={user.avatar_url} alt={user.display_name || ''} loading="lazy" decoding="async" />
                   ) : (
                     <div style={{
                       width: '100%',

--- a/src/components/call/CallHistoryItem.tsx
+++ b/src/components/call/CallHistoryItem.tsx
@@ -60,7 +60,7 @@ const CallHistoryItem: React.FC<CallHistoryItemProps> = ({
     >
       <IonAvatar slot="start" className="call-avatar">
         {avatarUrl ? (
-          <img src={avatarUrl} alt={displayName} />
+          <img src={avatarUrl} alt={displayName} loading="lazy" decoding="async" />
         ) : (
           <div className="call-avatar-placeholder" style={{ background: getAvatarColor(other) }}>
             {getInitial(other)}

--- a/src/components/friends/AddToChatPicker.tsx
+++ b/src/components/friends/AddToChatPicker.tsx
@@ -188,7 +188,7 @@ const AddToChatPicker: React.FC<AddToChatPickerProps> = ({
                 >
                   <IonAvatar slot="start" className="atc-avatar">
                     {avatarUrl ? (
-                      <img src={avatarUrl} alt="" />
+                      <img src={avatarUrl} alt="" loading="lazy" decoding="async" />
                     ) : (
                       <div className="atc-avatar-placeholder">
                         {initial}

--- a/src/components/friends/FriendCard.tsx
+++ b/src/components/friends/FriendCard.tsx
@@ -13,6 +13,7 @@ import {
 import { ellipse, ellipseOutline, personRemoveOutline } from 'ionicons/icons';
 import { type User, FRIEND_CATEGORIES } from '../../types/database';
 import { isUserOnline } from '../../services/presence';
+import { getOptimizedAvatarUrl } from '../../utils/imageUrl';
 
 interface FriendCardProps {
   user: User;
@@ -49,7 +50,12 @@ export const FriendCard: React.FC<FriendCardProps> = ({
       >
         <IonAvatar slot="start" className="friend-avatar">
           {user.avatar_url ? (
-            <img src={user.avatar_url} alt={user.display_name || ''} />
+            <img
+              src={getOptimizedAvatarUrl(user.avatar_url, 48)}
+              alt={user.display_name || ''}
+              loading="lazy"
+              decoding="async"
+            />
           ) : (
             <div className="avatar-placeholder" style={{ background: getAvatarColor(user) }}>
               {nickname?.charAt(0)?.toUpperCase() || getInitial(user)}

--- a/src/components/friends/FriendRequestCard.tsx
+++ b/src/components/friends/FriendRequestCard.tsx
@@ -45,7 +45,7 @@ export const FriendRequestCard: React.FC<FriendRequestCardProps> = ({
     <IonItem className="request-card" data-testid={`request-card-${friendshipId}`}>
       <IonAvatar slot="start" className="request-avatar">
         {displayUser.avatar_url ? (
-          <img src={displayUser.avatar_url} alt={displayUser.display_name || ''} />
+          <img src={displayUser.avatar_url} alt={displayUser.display_name || ''} loading="lazy" decoding="async" />
         ) : (
           <div className="avatar-placeholder">
             {displayUser.display_name?.charAt(0)?.toUpperCase() || '?'}

--- a/src/components/friends/FriendSettingsModal.tsx
+++ b/src/components/friends/FriendSettingsModal.tsx
@@ -74,7 +74,7 @@ export const FriendSettingsModal: React.FC<FriendSettingsModalProps> = ({
         <div className="fs-header">
           <IonAvatar className="fs-avatar">
             {friend.avatar_url ? (
-              <img src={friend.avatar_url} alt={friend.display_name || ''} />
+              <img src={friend.avatar_url} alt={friend.display_name || ''} loading="lazy" decoding="async" />
             ) : (
               <div className="fs-avatar-placeholder">
                 {friend.display_name?.charAt(0)?.toUpperCase() || '?'}

--- a/src/components/sos/SOSAlertCard.tsx
+++ b/src/components/sos/SOSAlertCard.tsx
@@ -64,7 +64,7 @@ export const SOSAlertCard: React.FC<SOSAlertCardProps> = ({
 
           <IonAvatar className="texter-avatar">
             {alert.texter.avatar_url ? (
-              <img src={alert.texter.avatar_url} alt={alert.texter.display_name || ''} />
+              <img src={alert.texter.avatar_url} alt={alert.texter.display_name || ''} loading="lazy" decoding="async" />
             ) : (
               <div className="avatar-placeholder">
                 {alert.texter.display_name?.charAt(0)?.toUpperCase() || '?'}

--- a/src/components/sos/SOSButton.tsx
+++ b/src/components/sos/SOSButton.tsx
@@ -8,6 +8,14 @@ import { sendSosAlert } from '../../services/sos';
 interface SOSButtonProps {
   onAlertSent?: () => void;
   size?: 'small' | 'default' | 'large';
+  /**
+   * Optional override for the button label. Defaults to the i18n key
+   * `sos.button`. Issue #43 introduces a per-chat variant labelled
+   * "Tillkalla Super" — passing `labelKey="sos.summonSuper"` lets the
+   * caller swap text without forking the component (the SOS action and
+   * safety guarantees stay identical).
+   */
+  labelKey?: string;
 }
 
 /**
@@ -17,6 +25,7 @@ interface SOSButtonProps {
 export const SOSButton: React.FC<SOSButtonProps> = ({
   onAlertSent,
   size = 'default',
+  labelKey = 'sos.button',
 }) => {
   const { t } = useTranslation();
   const [showConfirm, setShowConfirm] = useState(false);
@@ -53,7 +62,7 @@ export const SOSButton: React.FC<SOSButtonProps> = ({
         ) : (
           <>
             <IonIcon icon={alertCircle} slot="start" />
-            {t('sos.button')}
+            {t(labelKey)}
           </>
         )}
       </IonButton>

--- a/src/components/wall/WallComments.tsx
+++ b/src/components/wall/WallComments.tsx
@@ -106,7 +106,7 @@ const WallComments: React.FC<WallCommentsProps> = ({ postId, onCommentCountChang
       <div key={comment.id} className={`comment-item ${isReply ? 'comment-reply' : ''}`}>
         <IonAvatar className="comment-avatar">
           {comment.author?.avatar_url ? (
-            <img src={comment.author.avatar_url} alt="" />
+            <img src={comment.author.avatar_url} alt="" loading="lazy" decoding="async" />
           ) : (
             <div className="avatar-placeholder-sm">
               {(comment.author?.display_name || '?').charAt(0).toUpperCase()}

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -320,6 +320,7 @@
   },
   "sos": {
     "button": "SOS",
+    "summonSuper": "Tilkald Super",
     "confirmTitle": "Send SOS-alarm?",
     "confirmMessage": "Dette alarmerer din forælder med din placering.",
     "confirmYes": "JA, SEND SOS",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -320,6 +320,7 @@
   },
   "sos": {
     "button": "SOS",
+    "summonSuper": "Call Super",
     "confirmTitle": "Send SOS Alert?",
     "confirmMessage": "This will alert your guardian with your location.",
     "confirmYes": "YES, SEND SOS",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -320,6 +320,7 @@
   },
   "sos": {
     "button": "SOS",
+    "summonSuper": "Kutsu Super",
     "confirmTitle": "Lähetä SOS-hälytys?",
     "confirmMessage": "Tämä hälyttää huoltajasi sijainnillasi.",
     "confirmYes": "KYLLÄ, LÄHETÄ SOS",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -320,6 +320,7 @@
   },
   "sos": {
     "button": "SOS",
+    "summonSuper": "Tilkall Super",
     "confirmTitle": "Sende SOS-alarm?",
     "confirmMessage": "Dette varsler din foresatte med din posisjon.",
     "confirmYes": "JA, SEND SOS",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -320,6 +320,7 @@
   },
   "sos": {
     "button": "SOS",
+    "summonSuper": "Tillkalla Super",
     "confirmTitle": "Skicka SOS-larm?",
     "confirmMessage": "Detta larmar din vårdnadshavare med din plats.",
     "confirmYes": "JA, SKICKA SOS",

--- a/src/pages/AddFriend.tsx
+++ b/src/pages/AddFriend.tsx
@@ -202,6 +202,8 @@ const AddFriend: React.FC = () => {
                     <img
                       src={searchResult.avatar_url}
                       alt={searchResult.display_name || ''}
+                      loading="lazy"
+                      decoding="async"
                     />
                   ) : (
                     <div

--- a/src/pages/ChatInfo.tsx
+++ b/src/pages/ChatInfo.tsx
@@ -147,7 +147,7 @@ const ChatInfo: React.FC = () => {
                   {getChatDisplayName().charAt(0)?.toUpperCase() || '?'}
                 </div>
               ) : otherUser?.avatar_url ? (
-                <img src={otherUser.avatar_url} alt={otherUser.display_name || ''} />
+                <img src={otherUser.avatar_url} alt={otherUser.display_name || ''} loading="lazy" decoding="async" />
               ) : (
                 <div
                   className="avatar-placeholder large"
@@ -206,7 +206,7 @@ const ChatInfo: React.FC = () => {
                     <IonItem key={member.user_id} className="member-item">
                       <IonAvatar slot="start" className="member-avatar">
                         {member.user?.avatar_url ? (
-                          <img src={member.user.avatar_url} alt={member.user.display_name || ''} />
+                          <img src={member.user.avatar_url} alt={member.user.display_name || ''} loading="lazy" decoding="async" />
                         ) : (
                           <div className="avatar-placeholder small">
                             {(member.user?.display_name || '?').charAt(0)?.toUpperCase()}

--- a/src/pages/ChatList.tsx
+++ b/src/pages/ChatList.tsx
@@ -57,6 +57,7 @@ import {
 import { ChatSearchModal, MuteOptions } from '../components/chat';
 import { SkeletonLoader, EmptyStateIllustration } from '../components/common';
 import GroupAvatar from '../components/common/GroupAvatar';
+import { getOptimizedAvatarUrl } from '../utils/imageUrl';
 
 const ChatList: React.FC = () => {
   const { t } = useTranslation();
@@ -301,7 +302,12 @@ const ChatList: React.FC = () => {
                 size={48}
               />
             ) : avatar ? (
-              <img src={avatar} alt={displayName} loading="lazy" decoding="async" />
+              <img
+                src={getOptimizedAvatarUrl(avatar, 48)}
+                alt={displayName}
+                loading="lazy"
+                decoding="async"
+              />
             ) : (
               <div className="avatar-placeholder" style={{ background: avatarGradient }}>{initial}</div>
             )}

--- a/src/pages/ChatList.tsx
+++ b/src/pages/ChatList.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Virtuoso } from 'react-virtuoso';
 import { getDisplayName, getAvatarColor } from '../utils/userDisplay';
 import {
   IonPage,
@@ -453,10 +454,30 @@ const ChatList: React.FC = () => {
               </div>
             )}
 
-            {/* Active Chats */}
-            {activeChats.length > 0 && (
+            {/* Active Chats — virtualized (audit #36-P1) once the list
+                crosses a threshold where we'd otherwise render every
+                IonItemSliding upfront. Under the threshold we stay with
+                the plain list because Virtuoso's measurement layer adds
+                paint cost that doesn't pay off for ~10 items, and we
+                want the swipe gesture (IonItemSliding) to feel native
+                from the first frame. */}
+            {activeChats.length > 0 && activeChats.length <= 25 && (
               <IonList className="chat-list">
                 {activeChats.map(renderChatItem)}
+              </IonList>
+            )}
+            {activeChats.length > 25 && (
+              <IonList className="chat-list virtualized-chat-list">
+                <Virtuoso
+                  useWindowScroll
+                  data={activeChats}
+                  totalCount={activeChats.length}
+                  // Estimate based on the .chat-item paddings + avatar+two
+                  // lines of text. Virtuoso self-corrects after mount.
+                  defaultItemHeight={84}
+                  computeItemKey={(_, chat) => chat.id}
+                  itemContent={(index, chat) => renderChatItem(chat, index)}
+                />
               </IonList>
             )}
 

--- a/src/pages/ChatView.tsx
+++ b/src/pages/ChatView.tsx
@@ -384,6 +384,15 @@ const ChatView: React.FC = () => {
   const activeMemberCount = chat?.members.filter((m) => !m.left_at).length || 0;
   const hideCallForGroupSize = chat?.is_group && activeMemberCount > MAX_GROUP_CALL_PARTICIPANTS;
 
+  // Issue #43: the per-chat "Tillkalla Super" button replaces the previous
+  // always-on SOS button. Only show it to Texters in chats where at least
+  // one Super is a current (not left) member — anywhere else there's no
+  // Super to summon. The SOS action itself remains unblockable elsewhere
+  // (Settings + SOSOnlyView keep the global SOSButton intact for safety).
+  const chatHasActiveSuper = !!chat?.members.some(
+    (m) => !m.left_at && m.user?.role === UserRole.SUPER
+  );
+
   const getChatDisplayName = (): string => {
     if (!chat) return '';
     if (chat.name) return chat.name;
@@ -790,7 +799,9 @@ const ChatView: React.FC = () => {
             <IonButton onClick={() => setShowSearch(true)}>
               <IonIcon icon={searchOutline} />
             </IonButton>
-            {profile?.role === UserRole.TEXTER && <SOSButton size="small" />}
+            {profile?.role === UserRole.TEXTER && chatHasActiveSuper && (
+              <SOSButton size="small" labelKey="sos.summonSuper" />
+            )}
           </IonButtons>
         </IonToolbar>
       </IonHeader>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -239,7 +239,7 @@ const Dashboard: React.FC = () => {
                     >
                       <IonAvatar slot="start" className="member-avatar">
                         {member.avatar_url ? (
-                          <img src={member.avatar_url} alt={member.display_name || 'Avatar'} />
+                          <img src={member.avatar_url} alt={member.display_name || 'Avatar'} loading="lazy" decoding="async" />
                         ) : (
                           <div className="avatar-placeholder small" style={{ background: getAvatarColor(member) }}>
                             {getInitial(member)}

--- a/src/pages/Friends.tsx
+++ b/src/pages/Friends.tsx
@@ -19,6 +19,7 @@ import {
   IonRefresherContent,
   IonAlert,
   IonActionSheet,
+  IonToast,
   RefresherEventDetail,
 } from '@ionic/react';
 import { personAddOutline, peopleOutline, timeOutline, chatbubbleOutline, call, videocam, settingsOutline } from 'ionicons/icons';
@@ -72,6 +73,7 @@ const Friends: React.FC = () => {
     userId: string;
     name: string;
   } | null>(null);
+  const [unfriendError, setUnfriendError] = useState<string | null>(null);
 
   const loadData = useCallback(async () => {
     const [friendsResult, requestsResult, settingsResult] = await Promise.all([
@@ -99,7 +101,14 @@ const Friends: React.FC = () => {
 
   const handleUnfriend = async (friendshipId: string) => {
     const { error } = await unfriend(friendshipId);
-    if (!error) {
+    if (error) {
+      // Issue #42: previously a failed delete (e.g. an external-team friend
+      // hitting an RLS/precedence edge) was swallowed and the friend stayed
+      // in the list. Surface the error and re-fetch so the user sees state
+      // truthfully instead of clicking forever with no feedback.
+      setUnfriendError(error.message || t('friends.unfriendFailed', 'Kunde inte ta bort vännen'));
+      loadData();
+    } else {
       setFriends((prev) => prev.filter((f) => f.id !== friendshipId));
     }
     setUnfriendTarget(null);
@@ -444,6 +453,14 @@ const Friends: React.FC = () => {
               return next;
             });
           }}
+        />
+
+        <IonToast
+          isOpen={!!unfriendError}
+          message={unfriendError || ''}
+          duration={3500}
+          color="warning"
+          onDidDismiss={() => setUnfriendError(null)}
         />
 
         <AddToChatPicker

--- a/src/pages/InviteSuper.tsx
+++ b/src/pages/InviteSuper.tsx
@@ -27,6 +27,7 @@ import {
   type Invitation,
 } from '../services/invitations';
 import { getCurrentLanguage } from '../i18n';
+import { getPublicAppOrigin } from '../utils/appOrigin';
 
 const InviteSuper: React.FC = () => {
   const { t } = useTranslation();
@@ -88,7 +89,7 @@ const InviteSuper: React.FC = () => {
     }
 
     if (invitation) {
-      const link = `${window.location.origin}/invite/${invitation.token}?lang=${getCurrentLanguage()}`;
+      const link = `${getPublicAppOrigin()}/invite/${invitation.token}?lang=${getCurrentLanguage()}`;
 
       // Try to send invitation email via Edge Function
       const { error: sendError } = await sendInvitationEmail(

--- a/src/pages/NewChat.tsx
+++ b/src/pages/NewChat.tsx
@@ -175,7 +175,7 @@ const NewChat: React.FC = () => {
                   >
                     <IonAvatar slot="start" className="contact-avatar">
                       {contact.avatar_url ? (
-                        <img src={contact.avatar_url} alt={contact.display_name || ''} />
+                        <img src={contact.avatar_url} alt={contact.display_name || ''} loading="lazy" decoding="async" />
                       ) : (
                         <div
                           className="avatar-placeholder"

--- a/src/pages/OwnerApprovals.tsx
+++ b/src/pages/OwnerApprovals.tsx
@@ -211,6 +211,8 @@ const OwnerApprovals: React.FC = () => {
                       <img
                         src={group.texter.avatar_url}
                         alt={group.texter.display_name || ''}
+                        loading="lazy"
+                        decoding="async"
                       />
                     ) : (
                       <div className="avatar-placeholder small">
@@ -239,6 +241,8 @@ const OwnerApprovals: React.FC = () => {
                             <img
                               src={request.requester.avatar_url}
                               alt={request.requester.display_name || ''}
+                              loading="lazy"
+                              decoding="async"
                             />
                           ) : (
                             <div className="avatar-placeholder">

--- a/src/pages/OwnerOversight.tsx
+++ b/src/pages/OwnerOversight.tsx
@@ -274,6 +274,8 @@ const OwnerOversight: React.FC = () => {
                       <img
                         src={chat.texter.avatar_url}
                         alt={chat.texter.display_name || chat.texter.zemi_number}
+                        loading="lazy"
+                        decoding="async"
                       />
                     ) : (
                       <div

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -504,7 +504,7 @@ const Settings: React.FC = () => {
             <div className="profile-card" data-testid="profile-card">
               <div className="profile-avatar-section" onClick={handleAvatarUpload} style={{ cursor: 'pointer' }}>
                 {profile?.avatar_url ? (
-                  <img src={profile.avatar_url} alt="" className="profile-avatar-img" />
+                  <img src={profile.avatar_url} alt="" className="profile-avatar-img" loading="lazy" decoding="async" />
                 ) : (
                   <div className="profile-avatar-placeholder" style={{ background: getAvatarColor(profile) }}>
                     {getInitial(profile)}

--- a/src/pages/TexterDetail.tsx
+++ b/src/pages/TexterDetail.tsx
@@ -255,7 +255,7 @@ const TexterDetail: React.FC = () => {
           <div className="profile-card">
             <IonAvatar className="profile-avatar">
               {user.avatar_url ? (
-                <img src={user.avatar_url} alt={user.display_name || 'Avatar'} />
+                <img src={user.avatar_url} alt={user.display_name || 'Avatar'} loading="lazy" decoding="async" />
               ) : (
                 <div className="avatar-placeholder">
                   {user.display_name?.charAt(0)?.toUpperCase() || '?'}

--- a/src/services/friend.ts
+++ b/src/services/friend.ts
@@ -391,6 +391,20 @@ export async function rejectFriendRequest(
 
 /**
  * Unfriend (remove an accepted friendship).
+ *
+ * Issue #42: previously this DELETE chained .eq('status', ACCEPTED) and
+ * .or(requester=me OR addressee=me). RLS already enforces that only the
+ * two participants (or their Owner) may delete a friendship row, so the
+ * client-side filters were redundant — and the `.or()` combined with
+ * `.eq()` in PostgREST can yield surprising precedence when the row's
+ * other party sits in a different team (the .or filter is treated as a
+ * sibling AND of the previous .eq, but the underlying SELECT used to
+ * validate the row may itself be filtered by users-table RLS, dropping
+ * the row from the user's view and producing a silent zero-row delete).
+ *
+ * The fix is to delete by primary key only and let RLS gate authority.
+ * We then fetch the returning row count via .select() so the caller can
+ * tell a "no permission / row gone" case apart from a real DB error.
  */
 export async function unfriend(friendshipId: string): Promise<{ error: Error | null }> {
   try {
@@ -402,16 +416,24 @@ export async function unfriend(friendshipId: string): Promise<{ error: Error | n
       return { error: new Error('Not authenticated') };
     }
 
-    // Delete the friendship (either party can unfriend)
-    const { error } = await supabase
+    // Delete by id alone — RLS enforces participant/Owner authority. We
+    // ask PostgREST to return the deleted rows so we can detect a
+    // zero-row outcome (which would otherwise present as success).
+    const { data, error } = await supabase
       .from('friendships')
       .delete()
       .eq('id', friendshipId)
-      .eq('status', FriendshipStatus.ACCEPTED)
-      .or(`requester_id.eq.${user.id},addressee_id.eq.${user.id}`);
+      .select('id');
 
     if (error) {
       return { error: new Error(error.message) };
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      // Either RLS rejected the delete or the row was already gone.
+      // Surface as an explicit error so the UI can react (re-fetch or
+      // show a toast) instead of silently leaving the friend on screen.
+      return { error: new Error('Friendship could not be removed') };
     }
 
     return { error: null };

--- a/src/utils/appOrigin.ts
+++ b/src/utils/appOrigin.ts
@@ -1,0 +1,80 @@
+/**
+ * Returns the public origin to use when generating shareable Zemichat URLs
+ * (invitation links, deep links, etc.).
+ *
+ * Why this exists:
+ * - `window.location.origin` inside a Capacitor WebView resolves to
+ *   `http://localhost`, `https://localhost`, `capacitor://localhost` or
+ *   `ionic://localhost` depending on platform/version. None of those are
+ *   resolvable for an email recipient.
+ * - In a regular browser session (dev or hosted webapp on Vercel) we still
+ *   want to respect the real origin so test invites point at the correct
+ *   environment.
+ *
+ * Resolution order:
+ *  1. `import.meta.env.VITE_APP_URL` if defined and a valid https URL —
+ *     authoritative override set by the build pipeline (Codemagic / Vercel).
+ *  2. `window.location.origin` if it is NOT one of the Capacitor pseudo-
+ *     hosts (`localhost`, `localhost:5173`, `localhost:8100`, etc.).
+ *  3. Hard-coded production fallback `https://app.zemichat.com` — matches
+ *     `supabase/functions/_shared/escape-html.ts#isAllowedInviteLink` which
+ *     refuses to send invitation emails for any other host.
+ *
+ * The returned string never has a trailing slash, so callers can safely
+ * concatenate `/invite/...`.
+ */
+
+const PRODUCTION_FALLBACK = 'https://app.zemichat.com';
+
+const CAPACITOR_PSEUDO_HOSTS = new Set([
+  'localhost',
+  'localhost:5173',
+  'localhost:8100',
+  '127.0.0.1',
+  '127.0.0.1:5173',
+  '127.0.0.1:8100',
+]);
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function isValidPublicHttpsUrl(candidate: string | undefined): boolean {
+  if (!candidate || typeof candidate !== 'string') return false;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== 'https:') return false;
+    if (CAPACITOR_PSEUDO_HOSTS.has(parsed.host)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getPublicAppOrigin(): string {
+  // 1. Build-time override.
+  const fromEnv = (import.meta.env.VITE_APP_URL as string | undefined)?.trim();
+  if (fromEnv && isValidPublicHttpsUrl(fromEnv)) {
+    return stripTrailingSlash(fromEnv);
+  }
+
+  // 2. Runtime origin — only when not running inside a Capacitor WebView.
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    const origin = window.location.origin;
+    try {
+      const parsed = new URL(origin);
+      const isHttps = parsed.protocol === 'https:';
+      const isCapacitorScheme =
+        parsed.protocol === 'capacitor:' || parsed.protocol === 'ionic:';
+      const isPseudoHost = CAPACITOR_PSEUDO_HOSTS.has(parsed.host);
+      if (isHttps && !isPseudoHost && !isCapacitorScheme) {
+        return stripTrailingSlash(origin);
+      }
+    } catch {
+      // fall through to fallback
+    }
+  }
+
+  // 3. Production fallback.
+  return PRODUCTION_FALLBACK;
+}

--- a/src/utils/imageUrl.ts
+++ b/src/utils/imageUrl.ts
@@ -1,0 +1,70 @@
+/**
+ * Helpers for serving smaller/optimized image variants from Supabase
+ * Storage. Audit #36-P5: avatars and message images otherwise download
+ * at their original resolution (often 1024px+) even when rendered in a
+ * 48px slot, which burns bandwidth and decode time on mobile.
+ *
+ * Supabase Storage supports `?width=&height=&resize=cover&quality=`
+ * query params for transform-enabled buckets. For external URLs (e.g.
+ * Gravatar, third-party CDNs) we return the URL unchanged.
+ */
+
+const SUPABASE_STORAGE_HOST_FRAGMENT = '.supabase.co/storage/v1/object/';
+const SUPABASE_RENDER_PATH = '.supabase.co/storage/v1/render/image/';
+
+interface TransformOptions {
+  /** Target rendered width in CSS pixels — multiplied by DPR internally. */
+  width: number;
+  /** Target rendered height in CSS pixels (defaults to width). */
+  height?: number;
+  /** JPEG/WebP quality 20-100. Defaults to 80. */
+  quality?: number;
+  /** Resize strategy. Defaults to 'cover' (most useful for avatars). */
+  resize?: 'cover' | 'contain' | 'fill';
+}
+
+/**
+ * Return a Storage-transform URL for an avatar/thumb. Sizes are passed
+ * as logical CSS pixels — we multiply by devicePixelRatio (capped at 2)
+ * so retina renders crisp without quadrupling the byte cost on phones
+ * that report DPR 3+.
+ *
+ * Non-Supabase URLs and falsy inputs are returned unchanged so the
+ * helper is safe to apply broadly.
+ */
+export function getOptimizedImageUrl(
+  url: string | null | undefined,
+  opts: TransformOptions
+): string {
+  if (!url) return '';
+  if (!url.includes(SUPABASE_STORAGE_HOST_FRAGMENT) && !url.includes(SUPABASE_RENDER_PATH)) {
+    return url;
+  }
+
+  const dpr = typeof window !== 'undefined' && window.devicePixelRatio
+    ? Math.min(window.devicePixelRatio, 2)
+    : 1;
+  const width = Math.round(opts.width * dpr);
+  const height = Math.round((opts.height ?? opts.width) * dpr);
+  const quality = opts.quality ?? 80;
+  const resize = opts.resize ?? 'cover';
+
+  // Switch from /object/ to /render/image/ which is the transform
+  // endpoint. /render/image/ accepts public/sign URLs interchangeably.
+  let transformed = url.replace(
+    '/storage/v1/object/',
+    '/storage/v1/render/image/'
+  );
+
+  const sep = transformed.includes('?') ? '&' : '?';
+  transformed += `${sep}width=${width}&height=${height}&resize=${resize}&quality=${quality}`;
+  return transformed;
+}
+
+/** Convenience wrapper for avatar circles. */
+export function getOptimizedAvatarUrl(
+  url: string | null | undefined,
+  size: number = 48,
+): string {
+  return getOptimizedImageUrl(url, { width: size, height: size, resize: 'cover' });
+}

--- a/supabase/functions/send-invitation/index.ts
+++ b/supabase/functions/send-invitation/index.ts
@@ -33,8 +33,33 @@ serve(async (req) => {
     const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
     const resendApiKey = Deno.env.get('RESEND_API_KEY') ?? '';
+    // Allow overriding the From address per environment. Falls back to the
+    // verified production sender. Misconfiguration (e.g. an unverified
+    // sender) is one of the common causes that #40 is meant to surface.
+    const fromAddress = Deno.env.get('INVITE_FROM_ADDRESS') ?? 'Zemichat <noreply@zemichat.com>';
 
-    if (!resendApiKey) {
+    // Diagnostic: surface configuration gaps in logs so a missing env var
+    // doesn't masquerade as a generic "Failed to send" 5xx (issue #40).
+    if (!supabaseUrl || !supabaseAnonKey || !supabaseServiceKey) {
+      console.error('send-invitation: Supabase env vars missing', {
+        hasUrl: !!supabaseUrl,
+        hasAnon: !!supabaseAnonKey,
+        hasServiceRole: !!supabaseServiceKey,
+      });
+      return new Response(
+        JSON.stringify({ error: 'Server misconfigured: Supabase env vars missing' }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    if (!resendApiKey || !resendApiKey.startsWith('re_')) {
+      console.error('send-invitation: RESEND_API_KEY missing or malformed', {
+        present: !!resendApiKey,
+        prefixOk: resendApiKey.startsWith('re_'),
+      });
       return new Response(
         JSON.stringify({ error: 'Email service not configured' }),
         {
@@ -208,40 +233,105 @@ serve(async (req) => {
 </body>
 </html>`.trim();
 
-    // Send email via Resend API
-    const resendResponse = await fetch('https://api.resend.com/emails', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${resendApiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        from: 'Zemichat <noreply@zemichat.com>',
-        to: email,
-        // Subject is plain text in the SMTP envelope — no HTML escaping
-        // needed, but we strip control characters / newlines to prevent
-        // header injection.
-        subject: `${inviterName.replace(/[\r\n]+/g, ' ')} invited you to join ${teamName.replace(/[\r\n]+/g, ' ')} on Zemichat`,
-        html: htmlEmail,
-      }),
+    // Send email via Resend API. We log the call with a correlation id so a
+    // failure can be traced back to a specific invitation row (#40).
+    const correlationId = invitationId.slice(0, 8);
+    console.log(`send-invitation[${correlationId}]: posting to Resend`, {
+      to: email,
+      from: fromAddress,
+      invitationId,
     });
 
-    if (!resendResponse.ok) {
-      const resendError = await resendResponse.text();
-      console.error('Resend API error:', resendError);
+    let resendResponse: Response;
+    try {
+      resendResponse = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${resendApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: fromAddress,
+          to: email,
+          // Subject is plain text in the SMTP envelope — no HTML escaping
+          // needed, but we strip control characters / newlines to prevent
+          // header injection.
+          subject: `${inviterName.replace(/[\r\n]+/g, ' ')} invited you to join ${teamName.replace(/[\r\n]+/g, ' ')} on Zemichat`,
+          html: htmlEmail,
+        }),
+      });
+    } catch (networkErr) {
+      // Network-level failure (DNS, TLS, fetch abort). Distinguish from a
+      // 4xx/5xx so the client can prompt a retry rather than show "config".
+      console.error(`send-invitation[${correlationId}]: network failure calling Resend`, networkErr);
       return new Response(
-        JSON.stringify({ error: 'Failed to send invitation email' }),
+        JSON.stringify({
+          error: 'Could not reach email provider',
+          correlationId,
+        }),
         {
-          status: 502,
+          status: 503,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         }
       );
     }
 
+    if (!resendResponse.ok) {
+      const resendErrorBody = await resendResponse.text();
+      console.error(
+        `send-invitation[${correlationId}]: Resend rejected request`,
+        {
+          status: resendResponse.status,
+          body: resendErrorBody.slice(0, 500),
+        }
+      );
+
+      // Pick a friendly client-facing error that hints at the real cause.
+      // The raw Resend body is logged server-side only — we don't leak
+      // their wording in case it changes.
+      let clientMsg = 'Failed to send invitation email';
+      let clientStatus = 502;
+      if (resendResponse.status === 401 || resendResponse.status === 403) {
+        clientMsg = 'Email service authentication failed';
+        clientStatus = 500;
+      } else if (resendResponse.status === 422) {
+        clientMsg = 'Email rejected by provider (invalid recipient or sender)';
+        clientStatus = 400;
+      } else if (resendResponse.status === 429) {
+        clientMsg = 'Email provider rate limit hit, please try again shortly';
+        clientStatus = 429;
+      }
+
+      return new Response(
+        JSON.stringify({
+          error: clientMsg,
+          correlationId,
+          providerStatus: resendResponse.status,
+        }),
+        {
+          status: clientStatus,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Parse the Resend response so we can include the provider message-id
+    // in logs — invaluable if a recipient says "didn't receive it".
+    let resendBody: { id?: string } | null = null;
+    try {
+      resendBody = await resendResponse.json();
+    } catch {
+      // Resend should always return JSON on 2xx; tolerate the edge case.
+    }
+    console.log(`send-invitation[${correlationId}]: Resend accepted`, {
+      messageId: resendBody?.id ?? null,
+    });
+
     return new Response(
       JSON.stringify({
         success: true,
         message: 'Invitation email sent',
+        correlationId,
       }),
       {
         status: 200,
@@ -249,7 +339,14 @@ serve(async (req) => {
       }
     );
   } catch (err) {
-    console.error('send-invitation error:', err);
+    // Log the full error so the cause isn't hidden behind a generic 500.
+    // Issue #40 originally surfaced as "internal server error" with no
+    // breadcrumbs — that's what this branch addresses.
+    console.error('send-invitation: unhandled error', {
+      name: err instanceof Error ? err.name : 'unknown',
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
       {

--- a/supabase/migrations/20260512090000_fk_cascade_user_team_delete.sql
+++ b/supabase/migrations/20260512090000_fk_cascade_user_team_delete.sql
@@ -1,0 +1,286 @@
+-- ============================================================
+-- Migration: ON DELETE policy on FKs touching users/teams/chats
+-- Issue: #41 (https://github.com/BjorkhagenIngenjorsbyra/Zemichatv2/issues/41)
+-- ============================================================
+--
+-- WHY
+-- ---
+-- During team-delete-testing 2026-05-05 Erik tried to delete the team
+-- "Flickorna Holmgrenz" plus its users via the Supabase Admin API. The
+-- DELETE auth.users call walked into 11 FK-violations (23503), because the
+-- corresponding constraints were created without `ON DELETE CASCADE` or
+-- `ON DELETE SET NULL`. Every "delete my account" path in the client hits
+-- the same wall.
+--
+-- This migration normalises ON DELETE policy across the 11 constraints
+-- called out in the issue:
+--
+--   CASCADE   – the child row is meaningless without the parent
+--   SET NULL  – the child row should survive but lose its reference
+--
+-- | FK                                | Action     | Rationale                                                            |
+-- | --------------------------------- | ---------- | -------------------------------------------------------------------- |
+-- | poll_votes.user_id                | CASCADE    | a vote belongs to a user; if user is gone the vote is meaningless     |
+-- | polls.creator_id                  | SET NULL   | the poll itself survives, but creator becomes "[Borttagen användare]" |
+-- | message_reactions.user_id         | CASCADE    | reaction is per-user, no value without owner                          |
+-- | message_read_receipts.user_id     | CASCADE    | read receipt is per-user                                              |
+-- | messages.sender_id                | SET NULL   | preserve transcript history; render "Borttagen användare"             |
+-- | chat_members.user_id              | CASCADE    | membership is the join row; without user it has no meaning            |
+-- | push_tokens.user_id               | CASCADE    | token is device-per-user                                              |
+-- | texter_settings.user_id           | CASCADE    | settings row is per-user                                              |
+-- | call_logs.chat_id                 | CASCADE    | call log is per-chat; chat deletion takes call history with it        |
+-- | call_logs.initiator_id            | SET NULL   | preserve historic call entries when initiator is removed              |
+-- | chats.created_by                  | SET NULL   | chat survives owner removal so members keep their conversation        |
+--
+-- Several of these constraints (chat_members.user_id, push_tokens.user_id,
+-- texter_settings.user_id, message_reactions.user_id,
+-- message_read_receipts.user_id) already had ON DELETE CASCADE in the
+-- initial schema, but the issue reporter encountered FK violations on the
+-- production cluster — meaning either an early ad-hoc migration ran on
+-- prod without going through the migrations folder, or the constraint
+-- was recreated under a different name. We re-assert the policy on all
+-- 11 constraints regardless so prod and migrations agree.
+--
+-- The migration is idempotent: every statement looks up the existing FK
+-- in `pg_constraint`, drops it, and recreates it with the correct policy.
+-- If the constraint is already in the desired state it gets recreated
+-- with the same definition — cheap, no data movement.
+--
+-- DDL transactionality: Postgres wraps each migration file in an implicit
+-- transaction, so a failure in any step rolls the whole file back.
+-- ============================================================
+
+BEGIN;
+
+-- ------------------------------------------------------------
+-- Helper: drop FK by (table, column) and recreate with policy
+-- ------------------------------------------------------------
+-- We use a DO block per constraint so the migration handles both the
+-- "constraint exists under the default name" case and the "constraint
+-- was renamed somewhere along the line" case. The lookup is on the
+-- (table, column) pair rather than the constraint name.
+--
+-- `find_fk_name` returns the conname for a single-column FK on the
+-- requested table+column. If no FK is found the DO block raises so we
+-- notice rather than silently no-op.
+
+CREATE OR REPLACE FUNCTION pg_temp.find_fk_name(
+  p_schema text,
+  p_table  text,
+  p_column text
+)
+RETURNS text
+LANGUAGE plpgsql
+AS $func$
+DECLARE
+  v_conname text;
+BEGIN
+  SELECT c.conname
+    INTO v_conname
+    FROM pg_constraint c
+    JOIN pg_class      t ON t.oid = c.conrelid
+    JOIN pg_namespace  n ON n.oid = t.relnamespace
+    JOIN pg_attribute  a ON a.attrelid = c.conrelid AND a.attnum = c.conkey[1]
+   WHERE c.contype = 'f'
+     AND n.nspname = p_schema
+     AND t.relname = p_table
+     AND a.attname = p_column
+     AND array_length(c.conkey, 1) = 1
+   LIMIT 1;
+  RETURN v_conname;
+END
+$func$;
+
+-- ------------------------------------------------------------
+-- 1. poll_votes.user_id → auth.users(id) ON DELETE CASCADE
+-- ------------------------------------------------------------
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'poll_votes', 'user_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on poll_votes.user_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.poll_votes DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.poll_votes
+    ADD CONSTRAINT poll_votes_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+END $$;
+
+-- ------------------------------------------------------------
+-- 2. polls.creator_id → auth.users(id) ON DELETE SET NULL
+--    Drop NOT NULL so SET NULL is legal.
+-- ------------------------------------------------------------
+ALTER TABLE public.polls ALTER COLUMN creator_id DROP NOT NULL;
+
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'polls', 'creator_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on polls.creator_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.polls DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.polls
+    ADD CONSTRAINT polls_creator_id_fkey
+    FOREIGN KEY (creator_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+END $$;
+
+-- ------------------------------------------------------------
+-- 3. message_reactions.user_id → users(id) ON DELETE CASCADE
+-- ------------------------------------------------------------
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'message_reactions', 'user_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on message_reactions.user_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.message_reactions DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.message_reactions
+    ADD CONSTRAINT message_reactions_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+END $$;
+
+-- ------------------------------------------------------------
+-- 4. message_read_receipts.user_id → users(id) ON DELETE CASCADE
+-- ------------------------------------------------------------
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'message_read_receipts', 'user_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on message_read_receipts.user_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.message_read_receipts DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.message_read_receipts
+    ADD CONSTRAINT message_read_receipts_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+END $$;
+
+-- ------------------------------------------------------------
+-- 5. messages.sender_id → users(id) ON DELETE SET NULL
+--    Drop NOT NULL so SET NULL is legal. Client renders
+--    "Borttagen användare" when sender is null.
+-- ------------------------------------------------------------
+ALTER TABLE public.messages ALTER COLUMN sender_id DROP NOT NULL;
+
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'messages', 'sender_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on messages.sender_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.messages DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.messages
+    ADD CONSTRAINT messages_sender_id_fkey
+    FOREIGN KEY (sender_id) REFERENCES public.users(id) ON DELETE SET NULL;
+END $$;
+
+-- ------------------------------------------------------------
+-- 6. chat_members.user_id → users(id) ON DELETE CASCADE
+-- ------------------------------------------------------------
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'chat_members', 'user_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on chat_members.user_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.chat_members DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.chat_members
+    ADD CONSTRAINT chat_members_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+END $$;
+
+-- ------------------------------------------------------------
+-- 7. push_tokens.user_id → users(id) ON DELETE CASCADE
+-- ------------------------------------------------------------
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'push_tokens', 'user_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on push_tokens.user_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.push_tokens DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.push_tokens
+    ADD CONSTRAINT push_tokens_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+END $$;
+
+-- ------------------------------------------------------------
+-- 8. texter_settings.user_id → users(id) ON DELETE CASCADE
+-- ------------------------------------------------------------
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'texter_settings', 'user_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on texter_settings.user_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.texter_settings DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.texter_settings
+    ADD CONSTRAINT texter_settings_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+END $$;
+
+-- ------------------------------------------------------------
+-- 9. call_logs.chat_id → chats(id) ON DELETE CASCADE
+-- ------------------------------------------------------------
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'call_logs', 'chat_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on call_logs.chat_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.call_logs DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.call_logs
+    ADD CONSTRAINT call_logs_chat_id_fkey
+    FOREIGN KEY (chat_id) REFERENCES public.chats(id) ON DELETE CASCADE;
+END $$;
+
+-- ------------------------------------------------------------
+-- 10. call_logs.initiator_id → users(id) ON DELETE SET NULL
+--     Drop NOT NULL so SET NULL is legal.
+-- ------------------------------------------------------------
+ALTER TABLE public.call_logs ALTER COLUMN initiator_id DROP NOT NULL;
+
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'call_logs', 'initiator_id');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on call_logs.initiator_id not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.call_logs DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.call_logs
+    ADD CONSTRAINT call_logs_initiator_id_fkey
+    FOREIGN KEY (initiator_id) REFERENCES public.users(id) ON DELETE SET NULL;
+END $$;
+
+-- ------------------------------------------------------------
+-- 11. chats.created_by → users(id) ON DELETE SET NULL
+--     Drop NOT NULL so SET NULL is legal.
+-- ------------------------------------------------------------
+ALTER TABLE public.chats ALTER COLUMN created_by DROP NOT NULL;
+
+DO $$
+DECLARE c_name text;
+BEGIN
+  c_name := pg_temp.find_fk_name('public', 'chats', 'created_by');
+  IF c_name IS NULL THEN
+    RAISE EXCEPTION 'FK on chats.created_by not found';
+  END IF;
+  EXECUTE format('ALTER TABLE public.chats DROP CONSTRAINT %I', c_name);
+  ALTER TABLE public.chats
+    ADD CONSTRAINT chats_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+END $$;
+
+-- find_fk_name is a temp function (pg_temp.*) so it disappears when the
+-- migration's session ends — no cleanup needed.
+
+COMMIT;


### PR DESCRIPTION
## Summary

Batch fixes for v1.5.15 covering 6 issues + version bump.

### Issues fixed

| Issue | Type | Commit |
|-------|------|--------|
| #39 | Bug — invitation link uses production URL (not localhost) | c08bbc5 |
| #41 | DB — cascade/set null on user/team FKs | 9ed45ea |
| #40 | Bug — send-invitation edge function reliability + observability | 3cc395a |
| #42 | Bug — allow unfriending users outside own team | ccabd61 |
| #43 | UX — move SOS from global header to per-chat "Tillkalla Super" button | 630726b |
| #36 P1 | Perf — virtualize ChatList with react-virtuoso (ChatView was already virtualized) | 3899738 |
| #36 P5 | Perf — `loading="lazy"` + Storage `/render/image/` transforms on list avatars | b0bb690 |

### Performance audit (#36) — Top-5 status

- **P1 — react-virtuoso in ChatView + ChatList**: ChatView already virtualized in an earlier batch (audit fix #21). This PR adds Virtuoso to ChatList's active-chats section (threshold 25 entries) while preserving `IonItemSliding` swipe gestures. ✓
- **P2 — memoize context values in Auth / Subscription / Notification / Call**: verified already done in `useAuth`, `SubscriptionContext`, `NotificationContext`, and `CallContext` — all four wrap their value in `useMemo` with explicit deps. ✓ (already shipped)
- **P3 — stop SELECT-ing sender per realtime INSERT in subscribeToMessages**: verified already done — `senderCache` + `getSenderCached` in `src/services/message.ts`, primed by `getChatMessages` and exposed via `primeSenderCache`. ✓ (already shipped)
- **P4 — paginate getMyChats last-message query**: verified already done — `getMyChats` calls the `get_my_chats_with_last_message` RPC which returns pre-aggregated rows; no per-chat extra SELECTs. ✓ (already shipped)
- **P5 — `loading="lazy"` + Storage transforms on images**: applied `loading="lazy"` + `decoding="async"` to ~16 avatar surfaces (Friends, ChatInfo, Dashboard, NewChat, Settings, Owner approvals/oversight, AddFriend, share picker, etc). Added `src/utils/imageUrl.ts` with `getOptimizedAvatarUrl(url, size)` wrapping Supabase Storage `/render/image/` transform endpoint (DPR-aware, capped at 2x). Applied to ChatList + FriendCard as the two highest-traffic list surfaces; the helper makes incremental migration trivial elsewhere. ✓

### Version bump

`chore(release): v1.5.15 / vc 33` (2d741c5) — already on branch.

## Test plan

- [x] `npx tsc --noEmit` — passes clean
- [ ] `npm test` — RLS + Playwright suites require a running local Supabase / Playwright server; environment not available in this sandbox. To verify locally: `supabase start && npm test`.
- [ ] Manual smoke: send invitation, unfriend a cross-team friend, open chat with a Super-less Texter and confirm "Tillkalla Super" is hidden, open chat with a Super present and confirm button appears with correct label.
- [ ] Build a release candidate and run on real devices once merged.

## Notes for the reviewer

- The `send-invitation` fix is observability-heavy because no reproducer was available and the Supabase CLI does not expose a `functions logs` subcommand. Diagnostic env-var checks + correlation-id logging will surface the actual cause on the next failed attempt.
- `unfriend()` now trusts RLS instead of double-filtering; the RLS `friendships_delete_participant` policy already covers cross-team participants. No migration change needed.
- The `Tillkalla Super` button uses the same `SOSButton` component (now accepting a `labelKey` prop) — the safety guarantee that the SOS action cannot be blocked is preserved. Global SOSButton in Settings and SOSOnlyView are intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
