### PR TITLE
v1.5.16 batch (9 fixes)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.zemichat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 33
-        versionName "1.5.15"
+        versionCode 34
+        versionName "1.5.16"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
             debugSymbolLevel 'FULL'

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.zemichat.app',
   appName: 'Zemichat',
-  version: '1.5.15',
+  version: '1.5.16',
   webDir: 'dist',
   android: {
     buildOptions: {

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -242,6 +242,11 @@ Om Texter A (tillhör Owner 1) chattar med Texter B (tillhör Owner 2):
 
 ### 9.1 Alla användare
 - Push-notis för varje meddelande
+- Heads-up banner med text-preview (titel = avsändare, body = meddelande)
+  på både iOS och Android (issue #32). Android använder kanal
+  `messages_v2` med `IMPORTANCE_HIGH` (deklarerad som default-kanal i
+  AndroidManifest så FCM-utan-channel_id ändå hamnar rätt); iOS får
+  APNs-priority 10 + badge.
 - Push-notis när någon skickar dig en vänförfrågan eller accepterar din
   förfrågan (issue #7). Levereras av `friend-push` edge function via
   `notify_friend_request` Postgres-trigger på INSERT/UPDATE av

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -245,6 +245,14 @@ Om Texter A (tillhör Owner 1) chattar med Texter B (tillhör Owner 2):
 - Kan muta enskilda chattar (inga notiser, men synlig i listan)
 - "Stör ej" – tysta alla notiser under vald tid
 
+### 9.1.1 Owner/Super push-toggle per Texter (issue #6)
+- Owner och Super kan stänga av push-notiser för enskilda Texters i Texter-detaljvyn.
+- När togglen är av: `send-push` och `friend-push` edge-funktionerna hoppar
+  över FCM/APNs för den Textern. In-app meddelanden levereras fortfarande
+  via Realtime när appen är öppen.
+- Textern ser en banner i sina egna Settings ("Push-notiser avstängda av
+  ditt team") så det är transparent vad som händer.
+
 ### 9.2 Team Owner-specifika notiser
 | Händelse | Notis |
 |----------|-------|

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -114,9 +114,13 @@ Alla chattar är tekniskt grupper. En 1:1-chatt är en grupp med exakt två delt
 - Visa alla som reagerat
 
 #### Reply/Citera
-- Svep höger på meddelande för snabb reply
-- Citerat meddelande visas ovanför svaret
-- Tryck på citat för att hoppa till ursprungsmeddelandet
+- Svep höger på meddelande eller välj "Svara" i kontextmenyn för att starta svar
+- Citationsbox visas ovanför chat-inputen med avsändarens namn och utdrag —
+  textmeddelanden visar 1-3 raders preview, bild/video visar miniatyrbild
+- Citationen bäddas in via `messages.reply_to_id` så mottagaren ser samma
+  preview i bubblan
+- Tryck på citatet i bubblan → scroll till ursprungsmeddelandet och kort
+  highlight-flash på målbubblan
 
 #### Vidarebefordra
 - Vidarebefordra meddelande till annan chatt

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -242,6 +242,10 @@ Om Texter A (tillhör Owner 1) chattar med Texter B (tillhör Owner 2):
 
 ### 9.1 Alla användare
 - Push-notis för varje meddelande
+- Push-notis när någon skickar dig en vänförfrågan eller accepterar din
+  förfrågan (issue #7). Levereras av `friend-push` edge function via
+  `notify_friend_request` Postgres-trigger på INSERT/UPDATE av
+  `friendships`. Respekterar samma push-toggle som meddelandepushar.
 - Kan muta enskilda chattar (inga notiser, men synlig i listan)
 - "Stör ej" – tysta alla notiser under vald tid
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -130,6 +130,7 @@ Funktionskontroll per Texter (vilka features Owner har aktiverat).
 | quiet_hours_start | time | Schemalagd tystnad start |
 | quiet_hours_end | time | Schemalagd tystnad slut |
 | quiet_hours_days | int[] | Vilka veckodagar (1=mån, 7=sön) |
+| push_enabled | boolean | Owner/Super-styrd: när `false` skickar `send-push` ingen FCM/APNs-notis till Textern (issue #6) |
 
 ```sql
 CREATE TABLE texter_settings (
@@ -146,6 +147,10 @@ CREATE TABLE texter_settings (
   quiet_hours_start time,
   quiet_hours_end time,
   quiet_hours_days int[],
+  -- Owner/Super-styrd push-toggle (issue #6). När false hoppar
+  -- send-push och friend-push edge-funktionerna över FCM/APNs för
+  -- den här Textern. In-app realtime levereras fortfarande.
+  push_enabled boolean NOT NULL DEFAULT true,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -378,7 +378,9 @@ CREATE TABLE message_reactions (
   user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   emoji text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
-  UNIQUE(message_id, user_id, emoji)
+  -- Max one reaction per user per message (issue #34, WhatsApp/iMessage
+  -- semantics). A new emoji from the same user replaces the previous one.
+  CONSTRAINT message_reactions_one_per_user UNIQUE (message_id, user_id)
 );
 
 CREATE INDEX idx_reactions_message ON message_reactions(message_id);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zemichat",
   "private": true,
-  "version": "1.5.15",
+  "version": "1.5.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/chat/ChatInputToolbar.tsx
+++ b/src/components/chat/ChatInputToolbar.tsx
@@ -63,6 +63,8 @@ const ChatInputToolbar: React.FC<ChatInputToolbarProps> = ({
 }) => {
   const { t } = useTranslation();
   const textareaContainerRef = useRef<HTMLDivElement>(null);
+  // Issue #35: dedup pointerdown vs synthetic click on the emoji button.
+  const emojiHandledByPointerRef = useRef(false);
 
   // Auto-grow textarea
   const adjustTextareaHeight = useCallback(() => {
@@ -152,15 +154,38 @@ const ChatInputToolbar: React.FC<ChatInputToolbarProps> = ({
   return (
     <div className="chat-input-toolbar">
       {/* Smiley / Emoji toggle */}
-      {/* Issue #35: iOS Safari/WKWebView fires blur on the textarea before
-          our click lands on the emoji button when the keyboard is open, so
-          the panel never opens. preventDefault on mousedown/touchstart keeps
-          focus on the textarea long enough for the click to register. */}
+      {/* Issue #35: on iOS WKWebView the textarea blurs before our click
+          lands on the button, swallowing the tap. Earlier we tried
+          preventDefault on touchstart — but that ALSO prevents the
+          synthetic click iOS emits after touchend, so the panel never
+          opened.
+
+          Correct fix: drive the toggle from pointerdown for pointer/touch
+          input (fires before blur, so the keyboard collapse cycle never
+          gets a chance to swallow the activation), and keep onClick only
+          as a fallback for keyboard activation. A ref flag dedupes the
+          two paths so a single tap doesn't fire twice. */}
       <button
+        type="button"
         className={`toolbar-icon-btn ${isEmojiPanelOpen ? 'active' : ''}`}
+        onPointerDown={(e) => {
+          if (isSending) return;
+          // Keep textarea focus so iOS doesn't dismiss the keyboard mid-tap.
+          e.preventDefault();
+          emojiHandledByPointerRef.current = true;
+          onToggleEmojiPanel();
+        }}
         onMouseDown={(e) => e.preventDefault()}
-        onTouchStart={(e) => e.preventDefault()}
-        onClick={onToggleEmojiPanel}
+        onClick={() => {
+          // Pointerdown already handled the tap on touch/mouse — only run
+          // for keyboard-activated clicks (Enter/Space).
+          if (emojiHandledByPointerRef.current) {
+            emojiHandledByPointerRef.current = false;
+            return;
+          }
+          if (isSending) return;
+          onToggleEmojiPanel();
+        }}
         disabled={isSending}
         aria-label={t('chat.emojis')}
       >

--- a/src/components/chat/EmojiGifPanel.tsx
+++ b/src/components/chat/EmojiGifPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IonIcon, IonSpinner } from '@ionic/react';
 import { close, search } from 'ionicons/icons';
-import ReactEmojiPicker, { EmojiClickData, Theme } from 'emoji-picker-react';
+import ReactEmojiPicker, { EmojiClickData, EmojiStyle, Theme } from 'emoji-picker-react';
 import { searchGifs, getTrendingGifs, type GifResult } from '../../services/gif';
 import { hapticLight } from '../../utils/haptics';
 
@@ -154,6 +154,12 @@ const EmojiGifPanel: React.FC<EmojiGifPanelProps> = ({
           <ReactEmojiPicker
             onEmojiClick={handleEmojiClick}
             theme={Theme.AUTO}
+            /* Issue #5: emoji-picker-react defaults to EmojiStyle.APPLE which
+               loads CDN PNG sprites. On iOS WKWebView the sprites often fail
+               to load (CSP / network throttling) so the grid renders empty.
+               Forcing NATIVE makes each cell render via the system font
+               stack, which iOS handles natively via Apple Color Emoji. */
+            emojiStyle={EmojiStyle.NATIVE}
             searchPlaceholder={t('common.search')}
             width="100%"
             height="100%"

--- a/src/components/chat/EmojiPicker.tsx
+++ b/src/components/chat/EmojiPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { hapticLight } from '../../utils/haptics';
-import ReactEmojiPicker, { EmojiClickData, Theme } from 'emoji-picker-react';
+import ReactEmojiPicker, { EmojiClickData, EmojiStyle, Theme } from 'emoji-picker-react';
 
 interface EmojiPickerProps {
   onSelect: (emoji: string) => void;
@@ -38,6 +38,8 @@ const EmojiPicker: React.FC<EmojiPickerProps> = ({ onSelect, onClose }) => {
         <ReactEmojiPicker
           onEmojiClick={handleSelect}
           theme={Theme.AUTO}
+          /* Use native system emojis instead of CDN PNG sprites — see #5. */
+          emojiStyle={EmojiStyle.NATIVE}
           searchPlaceholder="Sök emoji..."
           width="100%"
           height={350}

--- a/src/components/chat/MessageReactions.tsx
+++ b/src/components/chat/MessageReactions.tsx
@@ -22,7 +22,10 @@ const MessageReactions: React.FC<MessageReactionsProps> = ({
           onClick={() => onToggle?.(reaction.emoji)}
           title={reaction.users.map((u) => u.display_name || 'User').join(', ')}
         >
-          <span className="reaction-emoji">{reaction.emoji}</span>
+          {/* Keying the emoji span by the emoji makes React re-mount it when
+              the user swaps their reaction (issue #34), so the CSS pop-in
+              animation fires — WhatsApp-style swap feedback. */}
+          <span key={reaction.emoji} className="reaction-emoji">{reaction.emoji}</span>
           <span className="reaction-count">{reaction.count}</span>
         </button>
       ))}
@@ -59,6 +62,18 @@ const MessageReactions: React.FC<MessageReactionsProps> = ({
 
         .reaction-emoji {
           font-size: 0.9rem;
+          display: inline-block;
+          animation: reaction-pop 0.18s ease-out;
+        }
+
+        @keyframes reaction-pop {
+          0%   { transform: scale(0.6); opacity: 0; }
+          60%  { transform: scale(1.25); opacity: 1; }
+          100% { transform: scale(1); }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .reaction-emoji { animation: none; }
         }
 
         .reaction-count {

--- a/src/components/chat/QuotedMessage.tsx
+++ b/src/components/chat/QuotedMessage.tsx
@@ -37,6 +37,11 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
     }
   };
 
+  // Issue #4: when the cited message is an image, render a tiny thumbnail
+  // next to the text — like WhatsApp's reply preview.
+  const showThumbnail =
+    (message.type === 'image' || message.type === 'video') && !!message.media_url;
+
   return (
     <div
       className={`quoted-message ${isOwn ? 'own' : 'other'}`}
@@ -52,6 +57,15 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
         </span>
         <span className="quote-text">{getPreview()}</span>
       </div>
+      {showThumbnail && (
+        <img
+          className="quote-thumb"
+          src={message.media_url ?? undefined}
+          alt=""
+          loading="lazy"
+          decoding="async"
+        />
+      )}
 
       <style>{`
         .quoted-message {
@@ -127,6 +141,15 @@ const QuotedMessage: React.FC<QuotedMessageProps> = ({
           -webkit-box-orient: vertical;
           overflow: hidden;
           text-overflow: ellipsis;
+        }
+
+        .quote-thumb {
+          width: 2.5rem;
+          height: 2.5rem;
+          object-fit: cover;
+          border-radius: 0.4rem;
+          flex-shrink: 0;
+          align-self: center;
         }
       `}</style>
     </div>

--- a/src/pages/ChatView.tsx
+++ b/src/pages/ChatView.tsx
@@ -1103,10 +1103,18 @@ const ChatView: React.FC = () => {
             padding: 0.5rem 1rem;
             background: hsl(var(--card));
             border-top: 1px solid hsl(var(--border));
+            /* Issue #33: cap the preview width so long quoted text wraps
+               into the bubble instead of pushing it off-screen. */
+            min-width: 0;
+            overflow: hidden;
           }
 
           .reply-preview > div {
-            flex: 1;
+            flex: 1 1 0;
+            /* Without min-width:0 a flex item won't shrink below its
+               intrinsic content width, which let long quotes clip past
+               the right edge. (Issue #33.) */
+            min-width: 0;
             margin: 0;
           }
 

--- a/src/services/wall.ts
+++ b/src/services/wall.ts
@@ -77,12 +77,17 @@ export async function createWallPost(params: {
       return { post: null, error: new Error('Not authenticated') };
     }
 
-    // Get user's team_id
-    const { data: profile } = await supabase
+    // Get user's team_id. Use maybeSingle() so a missing row returns
+    // data=null with no error (instead of PostgREST 406). Issue #14.
+    const { data: profile, error: profileError } = await supabase
       .from('users')
       .select('team_id')
       .eq('id', user.id)
-      .single();
+      .maybeSingle();
+
+    if (profileError) {
+      return { post: null, error: new Error(profileError.message) };
+    }
 
     if (!profile) {
       return { post: null, error: new Error('User profile not found') };


### PR DESCRIPTION
## Summary
v1.5.16 — 9 issue-fixar i ett batch ovanpå v1.5.15.

**Kod-fixar:**
- #14 `.single()` audit (wall.ts switched to maybeSingle; rest verified guaranteed-row)
- #33 Reply-preview wrap (flex `min-width: 0` on container + child)
- #34 Reactions: one-per-user invariant + WhatsApp-style animated swap (re-keyed emoji span)
- #35 Emoji-picker icon clickable on iOS (rewrote activation to onPointerDown, dedup via ref)
- #5  iOS emoji-picker grid (forced `EmojiStyle.NATIVE` — CDN sprites failed on iOS WKWebView)
- #4  Image/video thumbnail in reply citation box

**Doc-only (kod redan i tidigare batcher):**
- #7  Friend-request push (PRD §9.1)
- #6  Owner/Super push-toggle per Texter (SCHEMA + PRD §9.1.1)
- #32 Push heads-up banner + delivery (PRD §9.1)

**Release:**
- Android versionCode 33 → 34, versionName 1.5.15 → 1.5.16
- iOS CFBundleVersion sätts av Codemagic vid bygg

## Test plan
- [x] Typecheck passes (verifierat lokalt)
- [ ] Android Codemagic-bygge → Play Internal Testing
- [ ] iOS Codemagic-bygge → TestFlight
- [ ] Manuell test: emoji-picker öppnas på iOS (#35)
- [ ] Manuell test: reply-citation visar thumbnail för bild/video (#4)
- [ ] Manuell test: reaktion byts ut vid ny emoji (#34)
- [ ] Manuell test: långt citat wrappar i reply-preview (#33)

## Skipped
- #15 (call_log refactor) — kräver datamodells-genomgång, separat PR
- #28 (in-app reporting) — egen större feature
- #9  (instruktionsfilm) — extern video-produktion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
