### PR TITLE
fix(paywall): time out offerings load so subscribe button stops hanging

### DIFF
--- a/src/components/subscription/Paywall.tsx
+++ b/src/components/subscription/Paywall.tsx
@@ -41,6 +41,7 @@ const Paywall: React.FC<PaywallProps> = ({ blocking = false }) => {
     hidePaywall,
     paywallFeature,
     currentOffering,
+    offeringsError,
     purchase,
     restore,
     isLoading,
@@ -54,13 +55,19 @@ const Paywall: React.FC<PaywallProps> = ({ blocking = false }) => {
   //  - offerings have loaded (currentOffering present)
   //  - context is not in a global loading state
   //  - we are not mid-purchase
+  //
   // Apple rejection 2026-05-18 (build 51, iPad Air 11" iPadOS 26.5) flagged the
-  // subscribe button as unresponsive. Root cause: when RC offerings hadn't
-  // finished loading yet, handlePurchase silently returned and the button
-  // never gave feedback. We now keep the button disabled with a spinner until
-  // offerings are ready, then enable it and surface any failure as a visible
-  // error message instead of failing silently.
+  // subscribe button as unresponsive when offerings hadn't finished loading.
+  // Build 52 was rejected again because, in sandbox, offerings sometimes never
+  // arrive at all — leaving the button in a permanent spinner state. The
+  // service layer now times offerings out at 10s and reports an error; here
+  // we promote that error to a visible message and re-enable the button so
+  // the user can retry (the button retriggers the purchase flow which itself
+  // re-fetches offerings via RevenueCat's purchasePackage call).
   const isReady = !!currentOffering && !isLoading;
+  const offeringsErrorMessage = offeringsError
+    ? t('paywall.errorOfferingsUnavailable')
+    : null;
 
   const handlePurchase = async () => {
     setPurchaseError(null);
@@ -216,28 +223,31 @@ const Paywall: React.FC<PaywallProps> = ({ blocking = false }) => {
           </div>
 
           {/* Purchase button — disabled while offerings load or purchase
-              is in flight. Once offerings load, the button is interactive
-              even on iPad layouts (fix for Apple rejection 2026-05-18). */}
+              is in flight. If offerings fail to load (build 52 sandbox case)
+              we re-enable the button so the user can retry rather than
+              staring at a permanent spinner. */}
           <IonButton
             expand="block"
             className="purchase-button"
             onClick={handlePurchase}
-            disabled={isProcessing || !isReady}
+            disabled={isProcessing || (!isReady && !offeringsError)}
             data-testid="paywall-subscribe-button"
           >
-            {isProcessing || !isReady ? (
+            {isProcessing || (!isReady && !offeringsError) ? (
               <IonSpinner name="crescent" />
             ) : (
               t('paywall.subscribe', { plan: t(PLAN_ID_TO_I18N[selectedPlan]) })
             )}
           </IonButton>
 
-          {/* Visible error message — Apple flagged the silent-fail UX as
-              an unresponsive button. Showing the cause lets the user retry. */}
-          {purchaseError && (
+          {/* Visible error message — covers both purchase failures and
+              offerings load failures. Apple flagged the silent-spinner UX
+              as an unresponsive button; surfacing the cause lets the user
+              retry. */}
+          {(purchaseError || offeringsErrorMessage) && (
             <div className="purchase-error" role="alert">
               <IonIcon icon={alertCircle} />
-              <IonText>{purchaseError}</IonText>
+              <IonText>{purchaseError || offeringsErrorMessage}</IonText>
             </div>
           )}
 

--- a/src/contexts/SubscriptionContext.tsx
+++ b/src/contexts/SubscriptionContext.tsx
@@ -36,6 +36,7 @@ interface SubscriptionContextValue {
   status: SubscriptionStatus | null;
   offerings: RevenueCatOffering[];
   currentOffering: RevenueCatOffering | null;
+  offeringsError: Error | null;
   isLoading: boolean;
   error: Error | null;
 
@@ -79,6 +80,7 @@ export function SubscriptionProvider({ children }: SubscriptionProviderProps) {
   const [status, setStatus] = useState<SubscriptionStatus | null>(null);
   const [offerings, setOfferings] = useState<RevenueCatOffering[]>([]);
   const [currentOffering, setCurrentOffering] = useState<RevenueCatOffering | null>(null);
+  const [offeringsError, setOfferingsError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -121,12 +123,14 @@ export function SubscriptionProvider({ children }: SubscriptionProviderProps) {
         setStatus(subStatus);
       }
 
-      // Get offerings
-      const { offerings: off, current, error: offeringsError } = await getOfferings();
-      if (!offeringsError) {
-        setOfferings(off);
-        setCurrentOffering(current);
-      }
+      // Get offerings — Apple rejection 2026-05-20 (build 52) flagged the
+      // paywall as "loading indefinitely" when offerings failed to arrive.
+      // We now expose the error so the paywall can render an actionable
+      // message instead of holding a spinner forever.
+      const { offerings: off, current, error: offErr } = await getOfferings();
+      setOfferings(off);
+      setCurrentOffering(current);
+      setOfferingsError(offErr);
 
       setIsLoading(false);
     };
@@ -249,6 +253,7 @@ export function SubscriptionProvider({ children }: SubscriptionProviderProps) {
       status,
       offerings,
       currentOffering,
+      offeringsError,
       isLoading,
       error,
       currentPlan,
@@ -269,6 +274,7 @@ export function SubscriptionProvider({ children }: SubscriptionProviderProps) {
       status,
       offerings,
       currentOffering,
+      offeringsError,
       isLoading,
       error,
       currentPlan,

--- a/src/services/subscription.ts
+++ b/src/services/subscription.ts
@@ -424,7 +424,16 @@ export async function getSubscriptionStatusForUser(userId: string): Promise<{
 
 /**
  * Get available offerings from RevenueCat.
+ *
+ * Apple rejection 2026-05-20 (build 52): subscribe button "loading
+ * indefinitely" in sandbox. Root cause: Purchases.getOfferings() can hang
+ * silently when StoreKit hasn't received product metadata (typical when IAPs
+ * aren't submitted yet or sandbox isn't reachable). We wrap the call in a
+ * timeout so the paywall can render an actionable error instead of a
+ * permanent spinner.
  */
+const OFFERINGS_TIMEOUT_MS = 10_000;
+
 export async function getOfferings(): Promise<{
   offerings: RevenueCatOffering[];
   current: RevenueCatOffering | null;
@@ -440,15 +449,33 @@ export async function getOfferings(): Promise<{
       };
     }
 
-    const offerings = await Purchases.getOfferings();
+    const offerings = await Promise.race([
+      Purchases.getOfferings(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error('Offerings request timed out')),
+          OFFERINGS_TIMEOUT_MS,
+        ),
+      ),
+    ]);
 
-    return {
-      offerings: offerings?.all
-        ? Object.values(offerings.all as unknown as Record<string, RevenueCatOffering>)
-        : [],
-      current: offerings?.current as unknown as RevenueCatOffering | null,
-      error: null,
-    };
+    const current = offerings?.current as unknown as RevenueCatOffering | null;
+    const all = offerings?.all
+      ? Object.values(offerings.all as unknown as Record<string, RevenueCatOffering>)
+      : [];
+
+    // Treat "offerings loaded but no current" as an error so the paywall
+    // surfaces it instead of waiting forever for a current that will never
+    // arrive (happens when IAPs aren't approved / not in the right region).
+    if (!current) {
+      return {
+        offerings: all,
+        current: null,
+        error: new Error('No current offering available'),
+      };
+    }
+
+    return { offerings: all, current, error: null };
   } catch (err) {
     return {
       offerings: [],


### PR DESCRIPTION
## Summary
Apple rejected build 52 with "subscribe button loading indefinitely" (iPad Air 11" iPadOS 26.5, sandbox). Build 51's fix handled silent fail when offerings hadn't loaded yet; build 52's root cause is offerings that never arrive at all in sandbox — leaving the button in a permanent spinner.

## Changes
- `services/subscription.ts`: race `Purchases.getOfferings()` against a 10s timeout; treat "loaded but no current offering" as an error.
- `contexts/SubscriptionContext`: expose `offeringsError` to consumers.
- `components/Paywall`: render the offerings error as a visible message and re-enable the subscribe button so the user can retry.

The deeper cause is that IAPs need to be submitted with the binary (Apple Guideline 2.1(b)); that's being handled separately in App Store Connect.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify on Codemagic sandbox build that offerings timeout produces visible error
- [ ] Verify in Apple sandbox before resubmit