### PR TITLE
Fable-5 QA round: oversight name, quiet-hours i18n, a11y (1.5.18)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.zemichat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 35
-        versionName "1.5.17"
+        versionCode 36
+        versionName "1.5.18"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
             debugSymbolLevel 'FULL'

--- a/src/components/friends/FriendRequestCard.tsx
+++ b/src/components/friends/FriendRequestCard.tsx
@@ -80,6 +80,7 @@ export const FriendRequestCard: React.FC<FriendRequestCardProps> = ({
               size="small"
               onClick={() => onReject(friendshipId)}
               className="reject-button"
+              aria-label={t('a11y.rejectFriendRequest')}
             >
               <IonIcon icon={close} slot="icon-only" />
             </IonButton>
@@ -91,6 +92,7 @@ export const FriendRequestCard: React.FC<FriendRequestCardProps> = ({
               size="small"
               onClick={() => onAccept(friendshipId)}
               className="accept-button"
+              aria-label={t('a11y.acceptFriendRequest')}
             >
               <IonIcon icon={checkmark} slot="icon-only" />
             </IonButton>

--- a/src/components/owner/QuietHoursManager.tsx
+++ b/src/components/owner/QuietHoursManager.tsx
@@ -24,15 +24,16 @@ interface QuietHoursManagerProps {
   userId: string;
 }
 
-// Days of week: 0 = Sunday, 1 = Monday, etc.
+// Stored values follow JS getDay() (0 = Sunday), but display Monday-first to
+// match Swedish/ISO-8601 convention (Fable flagged the Sunday-first order).
 const DAYS_OF_WEEK = [
-  { value: 0, labelKey: 'quietHours.sunday' },
   { value: 1, labelKey: 'quietHours.monday' },
   { value: 2, labelKey: 'quietHours.tuesday' },
   { value: 3, labelKey: 'quietHours.wednesday' },
   { value: 4, labelKey: 'quietHours.thursday' },
   { value: 5, labelKey: 'quietHours.friday' },
   { value: 6, labelKey: 'quietHours.saturday' },
+  { value: 0, labelKey: 'quietHours.sunday' },
 ];
 
 /**
@@ -138,11 +139,10 @@ export const QuietHoursManager: React.FC<QuietHoursManagerProps> = ({
   };
 
   const formatTime = (time: string): string => {
+    // 24-hour format — matches the time picker and Swedish/Nordic convention
+    // (the app is Swedish-primary). Avoids the AM/PM inconsistency Fable flagged.
     const [hours, minutes] = time.split(':');
-    const hour = parseInt(hours, 10);
-    const ampm = hour >= 12 ? 'PM' : 'AM';
-    const hour12 = hour % 12 || 12;
-    return `${hour12}:${minutes} ${ampm}`;
+    return `${hours.padStart(2, '0')}:${(minutes ?? '00').padStart(2, '0')}`;
   };
 
   if (isLoading) {

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -877,6 +877,8 @@
     "cancel": "Annullér",
     "sendVoiceMessage": "Send talebesked",
     "openDashboard": "Oversigt",
+    "acceptFriendRequest": "Godkend venneanmodning",
+    "rejectFriendRequest": "Afvis venneanmodning",
     "searchMessages": "Søg beskeder",
     "close": "Luk"
   }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -877,6 +877,8 @@
     "cancel": "Cancel",
     "sendVoiceMessage": "Send voice message",
     "openDashboard": "Overview",
+    "acceptFriendRequest": "Accept friend request",
+    "rejectFriendRequest": "Reject friend request",
     "searchMessages": "Search messages",
     "close": "Close"
   }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -877,6 +877,8 @@
     "cancel": "Peruuta",
     "sendVoiceMessage": "Lähetä ääniviesti",
     "openDashboard": "Yleiskatsaus",
+    "acceptFriendRequest": "Hyväksy kaveripyyntö",
+    "rejectFriendRequest": "Hylkää kaveripyyntö",
     "searchMessages": "Hae viestejä",
     "close": "Sulje"
   }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -877,6 +877,8 @@
     "cancel": "Avbryt",
     "sendVoiceMessage": "Send talemelding",
     "openDashboard": "Oversikt",
+    "acceptFriendRequest": "Godta venneforespørsel",
+    "rejectFriendRequest": "Avslå venneforespørsel",
     "searchMessages": "Søk meldinger",
     "close": "Lukk"
   }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -883,6 +883,8 @@
     "cancel": "Avbryt",
     "sendVoiceMessage": "Skicka röstmeddelande",
     "openDashboard": "Översikt",
+    "acceptFriendRequest": "Godkänn vänförfrågan",
+    "rejectFriendRequest": "Avslå vänförfrågan",
     "searchMessages": "Sök meddelanden",
     "close": "Stäng"
   }

--- a/src/services/oversight.ts
+++ b/src/services/oversight.ts
@@ -95,6 +95,7 @@ export async function getTexterChats(): Promise<{
       .select(`
         chat_id,
         user_id,
+        display_name,
         user:users (*)
       `)
       .in('chat_id', chatIds)
@@ -107,10 +108,11 @@ export async function getTexterChats(): Promise<{
     const typedAllMembers = (allMembers || []) as unknown as {
       chat_id: string;
       user_id: string;
-      user: User;
+      display_name: string | null;
+      user: User | null;
     }[];
 
-    const membersByChat = new Map<string, { chat_id: string; user_id: string; user: User }[]>();
+    const membersByChat = new Map<string, { chat_id: string; user_id: string; display_name: string | null; user: User | null }[]>();
     for (const member of typedAllMembers) {
       const list = membersByChat.get(member.chat_id) || [];
       list.push(member);
@@ -145,12 +147,19 @@ export async function getTexterChats(): Promise<{
 
       // m.user is null when RLS hides that member's profile from the owner
       // (e.g. the texter's cross-team friend, whom the owner cannot SELECT).
-      // Drop those nulls — otherwise OwnerOversight crashes on
-      // otherMembers[0].display_name and the whole app falls back to the
-      // bootstrap error screen.
+      // The cross-team chat is still within the owner's oversight (PRD 8.2),
+      // so fall back to the snapshotted name on the membership row — otherwise
+      // the owner can't see WHO their child is talking to. Only drop a member
+      // if we have neither a live profile nor a snapshot.
       const otherMembers = (membersByChat.get(row.chat_id) || [])
         .filter((m) => m.user_id !== row.texter_id)
-        .map((m) => m.user)
+        .map((m) => {
+          if (m.user) return m.user;
+          if (m.display_name) {
+            return { id: m.user_id, display_name: m.display_name, role: 'texter' } as unknown as User;
+          }
+          return null;
+        })
         .filter((u): u is User => u != null);
 
       const lastMessage: Message | undefined = row.last_message_id

--- a/tests/explore/ai-explorer.mjs
+++ b/tests/explore/ai-explorer.mjs
@@ -19,11 +19,12 @@ import { chromium } from '@playwright/test';
 import Anthropic from '@anthropic-ai/sdk';
 import fs from 'fs';
 import path from 'path';
+import { execSync } from 'node:child_process';
 
 const BASE_URL = 'http://localhost:5173';
 const EMAIL = process.env.EXPLORE_EMAIL || 'user-aaaa0001@test.local'; // seeded owner
 const PASSWORD = process.env.EXPLORE_PASSWORD || 'test-password-123!';
-const MODEL = 'claude-opus-4-8';
+const MODEL = process.env.EXPLORE_MODEL || 'claude-opus-4-8';
 const MAX_STEPS = Number(process.env.EXPLORE_STEPS || 12);
 const OUT_DIR = path.resolve('tests/explore/runs');
 
@@ -69,6 +70,38 @@ const client = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY || fs.readFileSync('C:/Alva/config/anthropic_token.txt', 'utf-8').trim(),
 });
 
+// Brain routing: the standalone Anthropic SDK uses the developer API key
+// (pay-as-you-go). Routing through the Claude Code CLI instead uses the Max
+// subscription auth — which includes Fable 5 — so set EXPLORE_BRAIN=claude-code
+// (auto-on for fable models) to avoid burning API credits.
+const USE_CLAUDE_CODE = process.env.EXPLORE_BRAIN === 'claude-code' || MODEL.startsWith('claude-fable');
+
+// Call Claude Code headless with the prompt on stdin (no shell-quoting risk).
+// Returns the model's final text. Allows the Read tool so it can view a
+// screenshot referenced by path.
+function claudeCode(prompt) {
+  const cmd = `claude -p --model ${MODEL} --output-format json --max-turns 8 --allowedTools Read`;
+  const raw = execSync(cmd, {
+    input: prompt,
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 180000,
+  });
+  const parsed = JSON.parse(raw);
+  if (parsed.is_error) throw new Error(parsed.result || 'claude-code error');
+  return parsed.result;
+}
+
+// Lenient JSON extraction (model may wrap JSON in prose / code fences).
+function extractJson(text) {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const body = fenced ? fenced[1] : text;
+  const a = body.indexOf('{');
+  const b = body.lastIndexOf('}');
+  if (a === -1 || b === -1) throw new Error('no JSON in model output: ' + text.slice(0, 200));
+  return JSON.parse(body.slice(a, b + 1));
+}
+
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 async function login(page) {
@@ -109,7 +142,14 @@ function describeElements(els) {
     .join('\n');
 }
 
-async function decide(screenshotB64, url, elementList, history) {
+const DECIDE_SYSTEM =
+  'You are a curious, slightly impatient first-time user testing ZemiChat — a family chat app where a parent (Team Owner) oversees their children (Texters). ' +
+  'Explore the app like a real person: open things, read labels, try features. Your job is to surface anything confusing, broken, mislabelled, empty-where-it-should-not-be, or that simply feels off. ' +
+  'You are given a screenshot and a numbered list of the interactive elements currently on screen. Choose exactly ONE next action. ' +
+  'Prefer exploring parts you have not seen. Use "type" only into text fields (give the element index + text). Use "back" to leave a dead end. Use "done" when you have seen enough of the app. ' +
+  'Report issues you notice in the issues array (be specific; ok to be empty).';
+
+async function decide(screenshotB64, screenshotPath, url, elementList, history) {
   const recent = history.slice(-6).map((h) => `- ${h.action.type}${h.action.index != null ? ` [${h.action.index}]` : ''}: ${h.action.reason}`).join('\n') || '(none yet)';
   // Breadth nudge: if the last 3 steps were on the same screen, push elsewhere.
   const lastUrls = history.slice(-3).map((h) => h.url);
@@ -117,6 +157,18 @@ async function decide(screenshotB64, url, elementList, history) {
   const breadthNote = stuck
     ? '\n\nNOTE: You have spent the last 3 steps on THIS screen. Do not repeat the same action again — navigate somewhere new (go back, or open a different section like the dashboard/oversight, friends, or settings) to explore more of the app.'
     : '';
+
+  if (USE_CLAUDE_CODE) {
+    const prompt =
+      `${DECIDE_SYSTEM}\n\n` +
+      `First, look at the screenshot using the Read tool: ${screenshotPath.replace(/\\/g, '/')}\n\n` +
+      `Current URL: ${url}\n\nInteractive elements:\n${elementList}\n\nRecent actions:\n${recent}${breadthNote}\n\n` +
+      `Decide your next single action and note any issues. Respond with ONLY a JSON object (no prose, no code fences) of the form: ` +
+      `{"observation": string, "issues": [{"severity": "low"|"medium"|"high", "text": string}], "action": {"type": "click"|"type"|"back"|"done", "index": number, "text": string, "reason": string}}. ` +
+      `Omit index/text when not needed.`;
+    return extractJson(claudeCode(prompt));
+  }
+
   const res = await client.messages.create({
     model: MODEL,
     max_tokens: 1500,
@@ -144,9 +196,20 @@ async function decide(screenshotB64, url, elementList, history) {
   return JSON.parse(textBlock.text);
 }
 
+const SUMMARY_SYSTEM =
+  'You are a senior product/QA reviewer. You just explored ZemiChat as a first-time user. ' +
+  'Write a concise, honest UX report in Swedish markdown: (1) helhetsintryck, (2) vad som fungerade bra, ' +
+  '(3) problem/förvirring (grupperat efter allvarsgrad, konkret), (4) topp-3 rekommendationer. Var saklig och nedtonad.';
+
 async function summarize(history, issues) {
   const log = history.map((h, i) => `Step ${i + 1} @ ${h.url}\n  saw: ${h.observation}\n  did: ${h.action.type} ${h.action.reason}`).join('\n\n');
   const issueList = issues.map((x) => `- [${x.severity}] (step ${x.step}) ${x.text}`).join('\n') || '(none reported)';
+
+  if (USE_CLAUDE_CODE) {
+    const prompt = `${SUMMARY_SYSTEM}\n\nUtforskningslogg:\n\n${log}\n\nRapporterade problem:\n${issueList}\n\nSkriv rapporten.`;
+    return claudeCode(prompt);
+  }
+
   const res = await client.messages.create({
     model: MODEL,
     max_tokens: 4000,
@@ -182,13 +245,14 @@ async function main() {
     for (let step = 0; step < MAX_STEPS; step++) {
       await sleep(700);
       const shotBuf = await page.screenshot();
-      fs.writeFileSync(path.join(shotsDir, `step-${String(step + 1).padStart(2, '0')}.png`), shotBuf);
+      const shotPath = path.join(shotsDir, `step-${String(step + 1).padStart(2, '0')}.png`);
+      fs.writeFileSync(shotPath, shotBuf);
       const els = await collectElements(page);
       const url = page.url();
 
       let decision;
       try {
-        decision = await decide(shotBuf.toString('base64'), url, describeElements(els), history);
+        decision = await decide(shotBuf.toString('base64'), shotPath, url, describeElements(els), history);
       } catch (e) {
         console.log(`  step ${step + 1}: brain error: ${e.message}`);
         break;


### PR DESCRIPTION
Genuine Fable-5 explorer findings fixed (oversight counterpart name via snapshot [PRD 8.2], quiet-hours 24h + Monday-first day picker, accept/reject a11y labels), + explorer Claude Code/Max brain. Bump 1.5.18/vc36. Client-only. Queued: edited-history (PRD 8.4), toasts, more rounds.

?? Generated with Claude Code