### PR TITLE
followup: round-2 stragglers (oversight edit-history + SOS/role i18n)

### DIFF
--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -124,7 +124,8 @@
     "owner": "Owner",
     "super": "Super",
     "texter": "Texter",
-    "teamOwner": "Team Owner"
+    "teamOwner": "Team Owner",
+    "label": "Rolle"
   },
   "texter": {
     "createTitle": "Opret Texter",
@@ -366,6 +367,7 @@
     "confirmMessage": "Dette advarer en voksen.",
     "confirmYes": "JA, TILKALD",
     "confirmNo": "Annullér",
+    "autoCancelIn": "Annulleres automatisk om {{count}} s",
     "sent": "Voksen tilkaldt",
     "failed": "Alarmen kunne ikke sendes. Prøv igen.",
     "alertReceived": "Tilkald en voksen fra {{name}}",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -196,6 +196,7 @@
     "reply": "Svar",
     "react": "Reager",
     "edited": "redigeret",
+    "original": "Oprindelig tekst:",
     "gif": "GIF",
     "sticker": "Sticker",
     "poll": "Afstemning"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -124,7 +124,8 @@
     "owner": "Owner",
     "super": "Super",
     "texter": "Texter",
-    "teamOwner": "Team Owner"
+    "teamOwner": "Team Owner",
+    "label": "Role"
   },
   "texter": {
     "createTitle": "Create Texter",
@@ -366,6 +367,7 @@
     "confirmMessage": "This alerts an adult.",
     "confirmYes": "YES, CALL",
     "confirmNo": "Cancel",
+    "autoCancelIn": "Cancels automatically in {{count}} s",
     "sent": "Adult alerted",
     "failed": "The alert could not be sent. Please try again.",
     "alertReceived": "Call for an adult from {{name}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -196,6 +196,7 @@
     "reply": "Reply",
     "react": "React",
     "edited": "edited",
+    "original": "Original text:",
     "gif": "GIF",
     "sticker": "Sticker",
     "poll": "Poll"

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -196,6 +196,7 @@
     "reply": "Vastaa",
     "react": "Reagoi",
     "edited": "muokattu",
+    "original": "Alkuperäinen teksti:",
     "gif": "GIF",
     "sticker": "Tarra",
     "poll": "Äänestys"

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -124,7 +124,8 @@
     "owner": "Owner",
     "super": "Super",
     "texter": "Texter",
-    "teamOwner": "Team Owner"
+    "teamOwner": "Team Owner",
+    "label": "Rooli"
   },
   "texter": {
     "createTitle": "Luo Texter",
@@ -366,6 +367,7 @@
     "confirmMessage": "Tämä hälyttää aikuisen.",
     "confirmYes": "KYLLÄ, KUTSU",
     "confirmNo": "Peruuta",
+    "autoCancelIn": "Peruuntuu automaattisesti {{count}} s kuluttua",
     "sent": "Aikuinen kutsuttu",
     "failed": "Hälytystä ei voitu lähettää. Yritä uudelleen.",
     "alertReceived": "Aikuisen kutsu käyttäjältä {{name}}",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -196,6 +196,7 @@
     "reply": "Svar",
     "react": "Reager",
     "edited": "redigert",
+    "original": "Opprinnelig tekst:",
     "gif": "GIF",
     "sticker": "Sticker",
     "poll": "Avstemning"

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -124,7 +124,8 @@
     "owner": "Owner",
     "super": "Super",
     "texter": "Texter",
-    "teamOwner": "Team Owner"
+    "teamOwner": "Team Owner",
+    "label": "Rolle"
   },
   "texter": {
     "createTitle": "Opprett Texter",
@@ -366,6 +367,7 @@
     "confirmMessage": "Dette varsler en voksen.",
     "confirmYes": "JA, TILKALL",
     "confirmNo": "Avbryt",
+    "autoCancelIn": "Avbrytes automatisk om {{count}} s",
     "sent": "Voksen tilkalt",
     "failed": "Varselet kunne ikke sendes. Prøv igjen.",
     "alertReceived": "Tilkall en voksen fra {{name}}",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -124,7 +124,8 @@
     "owner": "Ägare",
     "super": "Super",
     "texter": "Texter",
-    "teamOwner": "Teamägare"
+    "teamOwner": "Teamägare",
+    "label": "Roll"
   },
   "texter": {
     "createTitle": "Skapa Texter",
@@ -366,6 +367,7 @@
     "confirmMessage": "Detta larmar en vuxen.",
     "confirmYes": "JA, TILLKALLA",
     "confirmNo": "Avbryt",
+    "autoCancelIn": "Avbryts automatiskt om {{count}} s",
     "sent": "Vuxen tillkallad",
     "failed": "Larmet kunde inte skickas. Försök igen.",
     "alertReceived": "Tillkalla Vuxen från {{name}}",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -196,6 +196,7 @@
     "reply": "Svara",
     "react": "Reagera",
     "edited": "redigerat",
+    "original": "Ursprunglig text:",
     "gif": "GIF",
     "sticker": "Sticker",
     "poll": "Omröstning"

--- a/src/pages/OwnerChatView.tsx
+++ b/src/pages/OwnerChatView.tsx
@@ -24,7 +24,7 @@ import {
   documentOutline,
   locationOutline,
 } from 'ionicons/icons';
-import { getOversightMessages } from '../services/oversight';
+import { getOversightMessages, getMessageEditHistory, type MessageEdit } from '../services/oversight';
 import { getChat, type ChatWithDetails } from '../services/chat';
 import { MessageType, type Message, type User } from '../types/database';
 import { useAuthContext } from '../contexts/AuthContext';
@@ -49,6 +49,7 @@ const OwnerChatView: React.FC = () => {
   const { profile } = useAuthContext();
   const [chat, setChat] = useState<ChatWithDetails | null>(null);
   const [messages, setMessages] = useState<(Message & { sender?: User })[]>([]);
+  const [editHistory, setEditHistory] = useState<Map<string, MessageEdit[]>>(new Map());
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const contentRef = useRef<HTMLIonContentElement>(null);
@@ -77,6 +78,13 @@ const OwnerChatView: React.FC = () => {
         return;
       }
       setMessages(chatMessages);
+
+      // Edit history (PRD 8.4): the owner sees the original text of edited messages.
+      const editedIds = chatMessages.filter((m) => m.is_edited && !m.deleted_at).map((m) => m.id);
+      if (editedIds.length > 0) {
+        const hist = await getMessageEditHistory(editedIds);
+        setEditHistory(hist);
+      }
 
       // Scroll to bottom
       setTimeout(() => {
@@ -312,6 +320,14 @@ const OwnerChatView: React.FC = () => {
                       {message.is_edited && !message.deleted_at && (
                         <div className="edited-indicator">
                           <span>{t('message.edited')}</span>
+                          {(editHistory.get(message.id) || []).length > 0 && (
+                            <div className="edit-history">
+                              <span className="edit-history-label">{t('message.original')}</span>
+                              <span className="edit-history-original">
+                                {editHistory.get(message.id)![0].old_content}
+                              </span>
+                            </div>
+                          )}
                         </div>
                       )}
                     </div>
@@ -499,6 +515,31 @@ const OwnerChatView: React.FC = () => {
             font-size: 0.7rem;
             color: hsl(var(--muted-foreground));
             font-style: italic;
+          }
+
+          .edit-history {
+            margin-top: 0.25rem;
+            padding: 0.4rem 0.5rem;
+            background: hsl(var(--muted) / 0.4);
+            border-left: 2px solid hsl(var(--border));
+            border-radius: 0.4rem;
+            font-style: normal;
+            display: flex;
+            flex-direction: column;
+            gap: 0.1rem;
+          }
+          .edit-history-label {
+            font-size: 0.65rem;
+            font-weight: 600;
+            color: hsl(var(--muted-foreground));
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+          }
+          .edit-history-original {
+            font-size: 0.85rem;
+            color: hsl(var(--foreground));
+            white-space: pre-wrap;
+            word-break: break-word;
           }
 
           .type-icon {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -562,7 +562,7 @@ const Settings: React.FC = () => {
                 <span className="profile-value mono">{profile?.zemi_number}</span>
               </div>
               <div className="profile-row">
-                <span className="profile-label">{t('texter.role', 'Roll')}</span>
+                <span className="profile-label">{t('roles.label')}</span>
                 <span className={`role-badge ${profile?.role}`}>
                   {profile?.role === 'owner'
                     ? t('roles.teamOwner')

--- a/src/services/oversight.ts
+++ b/src/services/oversight.ts
@@ -221,3 +221,32 @@ export async function getOversightMessages(
     };
   }
 }
+
+export interface MessageEdit {
+  old_content: string;
+  edited_at: string;
+}
+
+/**
+ * Edit history for messages, for owner oversight (PRD 8.4: edit history is
+ * visible to the Team Owner). Returns a map message_id -> edits (oldest first,
+ * so the first entry is the original text). RLS (message_edits_select_owner_
+ * oversight) already grants owners access to their texters' chats.
+ */
+export async function getMessageEditHistory(
+  messageIds: string[]
+): Promise<Map<string, MessageEdit[]>> {
+  const map = new Map<string, MessageEdit[]>();
+  if (messageIds.length === 0) return map;
+  const { data } = await supabase
+    .from('message_edits')
+    .select('message_id, old_content, edited_at')
+    .in('message_id', messageIds)
+    .order('edited_at', { ascending: true });
+  for (const e of (data ?? []) as unknown as { message_id: string; old_content: string; edited_at: string }[]) {
+    const list = map.get(e.message_id) || [];
+    list.push({ old_content: e.old_content, edited_at: e.edited_at });
+    map.set(e.message_id, list);
+  }
+  return map;
+}

--- a/tests/e2e/two-user-edit-history.spec.ts
+++ b/tests/e2e/two-user-edit-history.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression (PRD 8.4): the Team Owner sees the ORIGINAL text of an edited
+ * message in oversight, not just the "edited" label. The seed has an edited
+ * message in chatSuperToTexter with old_content 'Original content before edit'.
+ * Runs vs LOCAL Supabase.
+ */
+import { test, expect } from '@playwright/test';
+import { loginUser } from './helpers/login';
+
+const BASE_URL = 'http://localhost:5173';
+const SUPER_TEXTER_CHAT = 'cccc0003-0000-0000-0000-000000000003';
+
+test('owner sees original text of edited message in oversight', async ({ browser }) => {
+  const owner = await loginUser(browser, 'user-aaaa0001@test.local', 'test-password-123!', BASE_URL);
+  try {
+    await owner.page.goto(`${BASE_URL}/oversight/chat/${SUPER_TEXTER_CHAT}`);
+    await owner.page.waitForLoadState('networkidle');
+    await owner.page.waitForTimeout(1500);
+    await expect(owner.page.getByText('Original content before edit')).toBeVisible({ timeout: 8000 });
+  } finally {
+    await owner.context.close();
+  }
+});


### PR DESCRIPTION
Tar in 2 av 3 efterblivna round-2-commits (rebasade pa nya master efter round-3-merge):
- Visa originaltext av redigerade meddelanden for Owner (PRD 8.4) - integrerad i round-3:s robusta loadData.
- SOS auto-cancel-countdown i18n + korrekt roll-label (roles.label istallet for obefintlig texter.role).

Utelamnad: friends action-feedback-toasts - ersatt av round-3:s Friends-felhantering (undviker dubbla feedback-system).

tsc rent. Gar med i nasta versionsbump (ej 1.5.19 som redan ar ute).